### PR TITLE
refactor: Member 도메인의 department를 참조 테이블로 분리

### DIFF
--- a/src/main/java/com/equip/equiprental/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/auth/service/AuthServiceImpl.java
@@ -52,7 +52,7 @@ public class AuthServiceImpl implements AuthService {
                     .memberId(member.getMemberId())
                     .username(member.getUsername())
                     .name(member.getName())
-                    .department(member.getDepartment())
+                    .department(member.getDepartment().getDepartmentName())
                     .email(member.getEmail())
                     .role(member.getRole().name())
                     .status(member.getStatus().name())

--- a/src/main/java/com/equip/equiprental/common/config/SecurityConfig.java
+++ b/src/main/java/com/equip/equiprental/common/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/css/**", "/js/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/", "/signup", "/error/unauthorized").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/", "/api/v1/departments", "/signup", "/error/unauthorized").permitAll()
                         .requestMatchers(HttpMethod.POST,"/api/v1/members", "/api/v1/auth/login").permitAll()
                         .requestMatchers("/member", "/admin/equipment/registration").hasRole("ADMIN")
                         .requestMatchers("/admin/**").hasAnyRole("ADMIN", "MANAGER")

--- a/src/main/java/com/equip/equiprental/equipment/service/EquipmentItemServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/equipment/service/EquipmentItemServiceImpl.java
@@ -70,7 +70,7 @@ public class EquipmentItemServiceImpl implements EquipmentItemService{
             if ("RENTED".equals(dto.getNewStatus())) {
                 if (rentalItem != null) {
                     dto.setCurrentOwnerName(rentalItem.getRental().getMember().getName());
-                    dto.setCurrentOwnerDept(rentalItem.getRental().getMember().getDepartment());
+                    dto.setCurrentOwnerDept(rentalItem.getRental().getMember().getDepartment().getDepartmentName());
                 } else {
                     dto.setCurrentOwnerName("관리자");
                     dto.setCurrentOwnerDept("시스템");

--- a/src/main/java/com/equip/equiprental/member/controller/DepartmentController.java
+++ b/src/main/java/com/equip/equiprental/member/controller/DepartmentController.java
@@ -1,0 +1,33 @@
+package com.equip.equiprental.member.controller;
+
+import com.equip.equiprental.common.controller.ResponseController;
+import com.equip.equiprental.common.dto.ResponseDto;
+import com.equip.equiprental.common.interceptor.RequestTraceIdInterceptor;
+import com.equip.equiprental.member.dto.DepartmentDto;
+import com.equip.equiprental.member.service.DepartmentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/departments")
+public class DepartmentController implements ResponseController {
+    private final DepartmentService departmentService;
+
+    @GetMapping("")
+    public ResponseEntity<ResponseDto<List<DepartmentDto>>> getAll() {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("[회원 가입 요청 API] TraceId={}", traceId);
+
+        List<DepartmentDto> result = departmentService.getDepartmentList();
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "모든 부서명 조회 성공", result);
+    }
+}

--- a/src/main/java/com/equip/equiprental/member/domain/Department.java
+++ b/src/main/java/com/equip/equiprental/member/domain/Department.java
@@ -1,0 +1,24 @@
+package com.equip.equiprental.member.domain;
+
+import com.equip.equiprental.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="department_tbl")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Department extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="department_id")
+    private Long departmentId;
+
+    @Column(name="department_name")
+    private String departmentName;
+}

--- a/src/main/java/com/equip/equiprental/member/domain/Member.java
+++ b/src/main/java/com/equip/equiprental/member/domain/Member.java
@@ -22,7 +22,10 @@ public class Member extends BaseEntity {
     private String username;
     private String password;
     private String name;
-    private String department;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="department_id")
+    private Department department;
     private String email;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/equip/equiprental/member/dto/DepartmentDto.java
+++ b/src/main/java/com/equip/equiprental/member/dto/DepartmentDto.java
@@ -1,0 +1,13 @@
+package com.equip.equiprental.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class DepartmentDto {
+    private Long departmentId;
+    private String departmentName;
+}

--- a/src/main/java/com/equip/equiprental/member/dto/MemberDto.java
+++ b/src/main/java/com/equip/equiprental/member/dto/MemberDto.java
@@ -27,7 +27,7 @@ public class MemberDto {
         this.memberId = member.getMemberId();
         this.username = member.getUsername();
         this.name = member.getName();
-        this.department = member.getDepartment();
+        this.department = member.getDepartment().getDepartmentName();
         this.email = member.getEmail();
         this.status = member.getStatus().name(); // Enum이면 name()으로 String 변환
         this.role = member.getRole().name();

--- a/src/main/java/com/equip/equiprental/member/dto/SignUpRequest.java
+++ b/src/main/java/com/equip/equiprental/member/dto/SignUpRequest.java
@@ -14,6 +14,6 @@ public class SignUpRequest {
     private String password;
     private String confirmPassword;
     private String name;
-    private String department;
+    private Long departmentId;
     private String email;
 }

--- a/src/main/java/com/equip/equiprental/member/repository/DepartmentRepository.java
+++ b/src/main/java/com/equip/equiprental/member/repository/DepartmentRepository.java
@@ -1,0 +1,7 @@
+package com.equip.equiprental.member.repository;
+
+import com.equip.equiprental.member.domain.Department;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DepartmentRepository extends JpaRepository<Department, Long> {
+}

--- a/src/main/java/com/equip/equiprental/member/service/DepartmentService.java
+++ b/src/main/java/com/equip/equiprental/member/service/DepartmentService.java
@@ -1,0 +1,9 @@
+package com.equip.equiprental.member.service;
+
+import com.equip.equiprental.member.dto.DepartmentDto;
+
+import java.util.List;
+
+public interface DepartmentService {
+    List<DepartmentDto> getDepartmentList();
+}

--- a/src/main/java/com/equip/equiprental/member/service/DepartmentServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/member/service/DepartmentServiceImpl.java
@@ -1,0 +1,28 @@
+package com.equip.equiprental.member.service;
+
+import com.equip.equiprental.member.domain.Department;
+import com.equip.equiprental.member.dto.DepartmentDto;
+import com.equip.equiprental.member.repository.DepartmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DepartmentServiceImpl implements DepartmentService{
+    private final DepartmentRepository departmentRepository;
+
+    @Override
+    public List<DepartmentDto> getDepartmentList() {
+        List<Department> list = departmentRepository.findAll();
+
+
+        return list.stream()
+                .map(department -> DepartmentDto.builder()
+                        .departmentId(department.getDepartmentId())
+                        .departmentName(department.getDepartmentName())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/equip/equiprental/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/member/service/MemberServiceImpl.java
@@ -4,8 +4,10 @@ import com.equip.equiprental.common.exception.CustomException;
 import com.equip.equiprental.common.exception.ErrorType;
 import com.equip.equiprental.common.dto.PageResponseDto;
 import com.equip.equiprental.common.dto.SearchParamDto;
+import com.equip.equiprental.member.domain.Department;
 import com.equip.equiprental.member.domain.Member;
 import com.equip.equiprental.member.dto.*;
+import com.equip.equiprental.member.repository.DepartmentRepository;
 import com.equip.equiprental.member.repository.MemberRepository;
 import com.equip.equiprental.member.domain.MemberRole;
 import com.equip.equiprental.member.domain.MemberStatus;
@@ -22,6 +24,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
+    private final DepartmentRepository departmentRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
@@ -39,11 +42,14 @@ public class MemberServiceImpl implements MemberService {
             throw new CustomException(ErrorType.PASSWORD_MISMATCH);
         }
 
+        Department department = departmentRepository.findById(dto.getDepartmentId())
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
         Member member = Member.builder()
                 .username(dto.getUsername())
                 .password(passwordEncoder.encode(dto.getPassword()))
                 .name(dto.getName())
-                .department(dto.getDepartment())
+                .department(department)
                 .email(dto.getEmail())
                 .role(MemberRole.USER)
                 .status(MemberStatus.PENDING)
@@ -54,7 +60,7 @@ public class MemberServiceImpl implements MemberService {
                 .memberId(member.getMemberId())
                 .username(member.getUsername())
                 .name(member.getName())
-                .department(member.getDepartment())
+                .department(department.getDepartmentName())
                 .email(member.getEmail())
                 .createdAt(member.getCreatedAt())
                 .build();

--- a/src/main/java/com/equip/equiprental/rental/repository/dsl/RentalItemQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/rental/repository/dsl/RentalItemQRepoImpl.java
@@ -31,7 +31,7 @@ public class RentalItemQRepoImpl implements RentalItemQRepo{
         BooleanBuilder builder = new BooleanBuilder();
 
         if (paramDto.getDepartment() != null && !paramDto.getDepartment().isEmpty()) {
-            builder.and(i.rental.member.department.eq(paramDto.getDepartment()));
+            builder.and(i.rental.member.department.departmentName.eq(paramDto.getDepartment()));
         }
 
         if (paramDto.getMemberName() != null && !paramDto.getMemberName().isEmpty()) {

--- a/src/main/java/com/equip/equiprental/rental/repository/dsl/RentalQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/rental/repository/dsl/RentalQRepoImpl.java
@@ -31,7 +31,7 @@ public class RentalQRepoImpl implements RentalQRepo{
         builder.and(r.status.eq(RentalStatus.PENDING));
 
         if (paramDto.getDepartment() != null && !paramDto.getDepartment().isEmpty()) {
-            builder.and(r.member.department.eq(paramDto.getDepartment()));
+            builder.and(r.member.department.departmentName.eq(paramDto.getDepartment()));
         }
 
         if (paramDto.getMemberName() != null && !paramDto.getMemberName().isEmpty()) {

--- a/src/main/resources/static/js/member/signUp.js
+++ b/src/main/resources/static/js/member/signUp.js
@@ -1,14 +1,34 @@
+$(document).ready(function() {
+    loadDepartments();
+});
+
+function loadDepartments() {
+    $.ajax({
+        url: "/api/v1/departments", // 백엔드에서 부서 리스트 API
+        method: "GET",
+        contentType: "application/json"
+    }).done(function(response) {
+        const select = $("#department");
+        response.data.forEach(dept => {
+            // value에 department_id, 화면에 department_name
+            select.append(`<option value="${dept.departmentId}">${dept.departmentName}</option>`);
+        });
+    }).fail(function(xhr) {
+        handleServerError(xhr);
+    });
+}
+
 function signUp(){
     // 입력값 가져오기
     const username = $("#username").val().trim();
     const password = $("#password").val().trim();
     const confirmPassword = $("#confirmPassword").val().trim();
     const name = $("#name").val().trim();
-    const department = $("#department").val().trim();
+    const departmentId = $("#department").val();
     const email = $("#email").val().trim();
 
     // 간단한 검증
-    if (!username || !password || !confirmPassword || !name || !department || !email) {
+    if (!username || !password || !confirmPassword || !name || !departmentId || !email) {
         alert("모든 항목을 입력해주세요.");
         return;
     }
@@ -22,7 +42,7 @@ function signUp(){
             password: password,
             confirmPassword: confirmPassword,
             name: name,
-            department: department,
+            departmentId: departmentId,
             email: email
         })
     }).done(function(response) {

--- a/src/main/resources/templates/member/signUp.html
+++ b/src/main/resources/templates/member/signUp.html
@@ -38,8 +38,12 @@
 
     <div class="mb-3 form-group">
         <label for="department" class="form-label">부서</label>
-        <input id="department" type="text" class="form-control" placeholder="부서">
+        <select id="department" class="form-select">
+            <option value="">부서를 선택해주세요</option>
+            <!-- JS에서 옵션 채움 -->
+        </select>
     </div>
+
 
     <div class="mb-3 form-group">
         <label for="email" class="form-label">이메일</label>


### PR DESCRIPTION
## 개요
- #13 

## 타입
- **refactor:** 코드/패키지 구조 변경 (기능 변경 없음)

## 작업 사항
- `department` 컬럼을 `member_tbl`에서 제거하고 `department_id` FK로 변경
- Member 엔티티에서 `Department` 연관관계 매핑
- DepartmentService, DepartmentRepository 추가 및 부서 조회 기능 구현
- 프론트에서 사용자 가입 시 부서 선택 dropdown 적용
- 기존 코드에서 `member.getDepartment()` 사용하던 부분을 `member.getDepartment().getDepartmentName()`으로 변경
(관련 서비스/DTO/프론트 코드에서 부서 참조 방식 수정)