### PR TITLE
refactor: Equipment 도메인의 category/subCategory를 참조 테이블로 분리

### DIFF
--- a/src/main/java/com/equip/equiprental/common/dto/SearchParamDto.java
+++ b/src/main/java/com/equip/equiprental/common/dto/SearchParamDto.java
@@ -24,8 +24,8 @@ public class SearchParamDto {
     private String memberStatus;
     private String role;
 
-    private String category;
-    private String subCategory;
+    private Long categoryId;
+    private Long subCategoryId;
     private String model;
 
     private String equipmentStatus;
@@ -53,15 +53,6 @@ public class SearchParamDto {
             return MemberRole.valueOf(role.toUpperCase());
         } catch (IllegalArgumentException e) {
             throw new CustomException(ErrorType.INVALID_ROLE_REQUEST);
-        }
-    }
-
-    public EquipmentCategory getCategoryEnum() {
-        if (category == null || category.isBlank()) return null;
-        try{
-            return EquipmentCategory.valueOf(category.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(ErrorType.INVALID_CATEGORY_REQUEST);
         }
     }
 

--- a/src/main/java/com/equip/equiprental/common/dto/SearchParamDto.java
+++ b/src/main/java/com/equip/equiprental/common/dto/SearchParamDto.java
@@ -2,7 +2,6 @@ package com.equip.equiprental.common.dto;
 
 import com.equip.equiprental.common.exception.CustomException;
 import com.equip.equiprental.common.exception.ErrorType;
-import com.equip.equiprental.equipment.domain.EquipmentCategory;
 import com.equip.equiprental.equipment.domain.EquipmentStatus;
 import com.equip.equiprental.member.domain.MemberRole;
 import com.equip.equiprental.member.domain.MemberStatus;

--- a/src/main/java/com/equip/equiprental/equipment/controller/CategoryController.java
+++ b/src/main/java/com/equip/equiprental/equipment/controller/CategoryController.java
@@ -1,0 +1,44 @@
+package com.equip.equiprental.equipment.controller;
+
+import com.equip.equiprental.common.controller.ResponseController;
+import com.equip.equiprental.common.dto.ResponseDto;
+import com.equip.equiprental.common.interceptor.RequestTraceIdInterceptor;
+import com.equip.equiprental.equipment.dto.CategoryDto;
+import com.equip.equiprental.equipment.dto.SubCategoryDto;
+import com.equip.equiprental.equipment.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/categories")
+public class CategoryController implements ResponseController {
+    private final CategoryService categoryService;
+
+    @GetMapping("")
+    public ResponseEntity<ResponseDto<List<CategoryDto>>> getCategories() {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("[모든 카테고리 조회 요청 API] TraceId={}", traceId);
+
+        List<CategoryDto> result = categoryService.getCategories();
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "모든 카테고리 조회 성공", result);
+    }
+
+    @GetMapping("/{categoryId}/sub-categories")
+    public ResponseEntity<ResponseDto<List<SubCategoryDto>>> getSubCategories(@PathVariable Long categoryId) {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("[서브 카테고리 조회 요청 API] TraceId={}", traceId);
+
+        List<SubCategoryDto> result = categoryService.getSubCategories(categoryId);
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "서브 카테고리 조회 성공", result);
+    }
+}

--- a/src/main/java/com/equip/equiprental/equipment/domain/Category.java
+++ b/src/main/java/com/equip/equiprental/equipment/domain/Category.java
@@ -1,0 +1,26 @@
+package com.equip.equiprental.equipment.domain;
+
+import com.equip.equiprental.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="category_tbl")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Category extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="category_id")
+    private Long categoryId;
+
+    @Column(name="category_code")
+    private String categoryCode;
+
+    private String label;
+}

--- a/src/main/java/com/equip/equiprental/equipment/domain/Equipment.java
+++ b/src/main/java/com/equip/equiprental/equipment/domain/Equipment.java
@@ -21,11 +21,9 @@ public class Equipment extends BaseEntity {
     @Column(name="equipment_id")
     private Long equipmentId;
 
-    @Enumerated(EnumType.STRING)
-    private EquipmentCategory category;
-
-    @Column(name="sub_category")
-    private String subCategory;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="sub_category_id")
+    private SubCategory subCategory;
 
     private String model;
 

--- a/src/main/java/com/equip/equiprental/equipment/domain/EquipmentCategory.java
+++ b/src/main/java/com/equip/equiprental/equipment/domain/EquipmentCategory.java
@@ -1,9 +1,0 @@
-package com.equip.equiprental.equipment.domain;
-
-public enum EquipmentCategory {
-    OFFICE_SUPPLIES,    // 사무/문구류
-    ELECTRONICS,        // 전자제품류
-    FURNITURE,          // 비품/가구류
-    TOOLS,              // 공구/기자재
-    SAFETY_EQUIPMENT     // 안전/보호장비
-}

--- a/src/main/java/com/equip/equiprental/equipment/domain/SubCategory.java
+++ b/src/main/java/com/equip/equiprental/equipment/domain/SubCategory.java
@@ -1,0 +1,27 @@
+package com.equip.equiprental.equipment.domain;
+
+import com.equip.equiprental.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="sub_category_tbl")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SubCategory extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="sub_category_id")
+    private Long subCategoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="category_id")
+    private Category category;
+
+    private String label;
+}

--- a/src/main/java/com/equip/equiprental/equipment/dto/CategoryDto.java
+++ b/src/main/java/com/equip/equiprental/equipment/dto/CategoryDto.java
@@ -1,0 +1,14 @@
+package com.equip.equiprental.equipment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CategoryDto {
+    private Long categoryId;
+    private String categoryCode;
+    private String label;
+}

--- a/src/main/java/com/equip/equiprental/equipment/dto/EquipmentRegisterRequest.java
+++ b/src/main/java/com/equip/equiprental/equipment/dto/EquipmentRegisterRequest.java
@@ -2,7 +2,6 @@ package com.equip.equiprental.equipment.dto;
 
 import com.equip.equiprental.common.exception.CustomException;
 import com.equip.equiprental.common.exception.ErrorType;
-import com.equip.equiprental.equipment.domain.EquipmentCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/equip/equiprental/equipment/dto/EquipmentRegisterRequest.java
+++ b/src/main/java/com/equip/equiprental/equipment/dto/EquipmentRegisterRequest.java
@@ -1,7 +1,5 @@
 package com.equip.equiprental.equipment.dto;
 
-import com.equip.equiprental.common.exception.CustomException;
-import com.equip.equiprental.common.exception.ErrorType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,19 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class EquipmentRegisterRequest {
-    private String category;
-    private String subCategory;
+    private Long subCategoryId;
     private String model;
     private Integer stock;
-
-    public EquipmentCategory getCategoryEnum(){
-        if(this.category == null){
-            throw new CustomException(ErrorType.INVALID_EQUIP_CATEGORY_REQUEST);
-        }
-        try{
-            return EquipmentCategory.valueOf(this.category);
-        }catch(IllegalArgumentException e){
-            throw new CustomException(ErrorType.INVALID_EQUIP_CATEGORY_REQUEST);
-        }
-    }
 }

--- a/src/main/java/com/equip/equiprental/equipment/dto/SubCategoryDto.java
+++ b/src/main/java/com/equip/equiprental/equipment/dto/SubCategoryDto.java
@@ -1,0 +1,14 @@
+package com.equip.equiprental.equipment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SubCategoryDto {
+    private Long subCategoryId;
+    private Long categoryId;
+    private String label;
+}

--- a/src/main/java/com/equip/equiprental/equipment/repository/CategoryRepository.java
+++ b/src/main/java/com/equip/equiprental/equipment/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.equip.equiprental.equipment.repository;
+
+import com.equip.equiprental.equipment.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/equip/equiprental/equipment/repository/EquipmentRepository.java
+++ b/src/main/java/com/equip/equiprental/equipment/repository/EquipmentRepository.java
@@ -1,7 +1,6 @@
 package com.equip.equiprental.equipment.repository;
 
 import com.equip.equiprental.equipment.domain.Equipment;
-import com.equip.equiprental.equipment.domain.EquipmentCategory;
 import com.equip.equiprental.equipment.repository.dsl.EquipmentQRepo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/equip/equiprental/equipment/repository/EquipmentRepository.java
+++ b/src/main/java/com/equip/equiprental/equipment/repository/EquipmentRepository.java
@@ -1,5 +1,6 @@
 package com.equip.equiprental.equipment.repository;
 
+import com.equip.equiprental.equipment.domain.Category;
 import com.equip.equiprental.equipment.domain.Equipment;
 import com.equip.equiprental.equipment.repository.dsl.EquipmentQRepo;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,6 +13,6 @@ public interface EquipmentRepository extends JpaRepository<Equipment, Long>, Equ
     Optional<Equipment> findByEquipmentId(Long equipmentId);
     Optional<Equipment> findByModel(String model);
 
-    @Query("SELECT e.category FROM Equipment e WHERE e.equipmentId = :equipmentId")
-    EquipmentCategory findCategoryByEquipmentId(@Param("equipmentId") Long equipmentId);
+    @Query("SELECT e.subCategory.category FROM Equipment e WHERE e.equipmentId = :equipmentId")
+    Category findCategoryByEquipmentId(@Param("equipmentId") Long equipmentId);
 }

--- a/src/main/java/com/equip/equiprental/equipment/repository/SubCategoryRepository.java
+++ b/src/main/java/com/equip/equiprental/equipment/repository/SubCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.equip.equiprental.equipment.repository;
+
+import com.equip.equiprental.equipment.domain.SubCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SubCategoryRepository extends JpaRepository<SubCategory, Long> {
+    List<SubCategory> findByCategoryCategoryId(Long categoryId);
+}

--- a/src/main/java/com/equip/equiprental/equipment/repository/dsl/EquipmentQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/equipment/repository/dsl/EquipmentQRepoImpl.java
@@ -32,11 +32,11 @@ public class EquipmentQRepoImpl implements EquipmentQRepo {
 
         // 동적 조건을 누적할 BooleanBuilder 생성
         BooleanBuilder builder = new BooleanBuilder();
-        if (paramDto.getCategoryEnum() != null) {
-            builder.and(e.category.eq(paramDto.getCategoryEnum()));
+        if (paramDto.getCategoryId() != null) {
+            builder.and(e.subCategory.category.categoryId.eq(paramDto.getCategoryId()));
         }
-        if (paramDto.getSubCategory() != null && !paramDto.getSubCategory().isEmpty()) {
-            builder.and(e.subCategory.eq(paramDto.getSubCategory()));
+        if (paramDto.getSubCategoryId() != null) {
+            builder.and(e.subCategory.subCategoryId.eq(paramDto.getSubCategoryId()));
         }
         if (paramDto.getModel() != null && !paramDto.getModel().isEmpty()) {
             builder.and(e.model.containsIgnoreCase(paramDto.getModel()));
@@ -47,8 +47,8 @@ public class EquipmentQRepoImpl implements EquipmentQRepo {
                 // 메인 쿼리, EquipmentDto 생성자의 파라미터 순서에 맞춰 값 세팅
                 .select(Projections.constructor(EquipmentDto.class,
                         e.equipmentId,
-                        e.category.stringValue(),
-                        e.subCategory,
+                        e.subCategory.category.label,
+                        e.subCategory.label,
                         e.model,
                         // available 재고, 서브 쿼리 (JPAExpressions.select)
                         // .count()는 NumberExpression<Long> 반환 -> 타입 변환

--- a/src/main/java/com/equip/equiprental/equipment/service/CategoryService.java
+++ b/src/main/java/com/equip/equiprental/equipment/service/CategoryService.java
@@ -1,0 +1,11 @@
+package com.equip.equiprental.equipment.service;
+
+import com.equip.equiprental.equipment.dto.CategoryDto;
+import com.equip.equiprental.equipment.dto.SubCategoryDto;
+
+import java.util.List;
+
+public interface CategoryService {
+    List<CategoryDto> getCategories();
+    List<SubCategoryDto> getSubCategories(Long categoryId);
+}

--- a/src/main/java/com/equip/equiprental/equipment/service/CategoryServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/equipment/service/CategoryServiceImpl.java
@@ -1,0 +1,45 @@
+package com.equip.equiprental.equipment.service;
+
+import com.equip.equiprental.equipment.domain.Category;
+import com.equip.equiprental.equipment.domain.SubCategory;
+import com.equip.equiprental.equipment.dto.CategoryDto;
+import com.equip.equiprental.equipment.dto.SubCategoryDto;
+import com.equip.equiprental.equipment.repository.CategoryRepository;
+import com.equip.equiprental.equipment.repository.SubCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService{
+    private final CategoryRepository categoryRepository;
+    private final SubCategoryRepository subCategoryRepository;
+
+    @Override
+    public List<CategoryDto> getCategories() {
+        List<Category> categories = categoryRepository.findAll();
+
+        return categories.stream()
+                .map(c -> CategoryDto.builder()
+                        .categoryId(c.getCategoryId())
+                        .categoryCode(c.getCategoryCode())
+                        .label(c.getLabel())
+                        .build())
+                .toList();
+    }
+
+    @Override
+    public List<SubCategoryDto> getSubCategories(Long categoryId) {
+        List<SubCategory> subCategories = subCategoryRepository.findByCategoryCategoryId(categoryId);
+
+        return subCategories.stream()
+                .map(sc -> SubCategoryDto.builder()
+                        .subCategoryId(sc.getSubCategoryId())
+                        .categoryId(sc.getCategory().getCategoryId())
+                        .label(sc.getLabel())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/equip/equiprental/equipment/util/EquipmentCodeMap.java
+++ b/src/main/java/com/equip/equiprental/equipment/util/EquipmentCodeMap.java
@@ -28,7 +28,7 @@ public class EquipmentCodeMap {
         subCategoryCodeMap.put("오디오장비(스피커/마이크)", "AD");
         subCategoryCodeMap.put("외장저장장치(SSD/HDD)", "ST");
         subCategoryCodeMap.put("사무용 의자", "CH");
-        subCategoryCodeMap.put("책상/테이블", "DS");
+        subCategoryCodeMap.put("책상", "DS");
         subCategoryCodeMap.put("서랍장/캐비닛", "CA");
         subCategoryCodeMap.put("이동식 파티션", "PT");
         subCategoryCodeMap.put("화이트보드", "WB");

--- a/src/main/java/com/equip/equiprental/member/controller/DepartmentController.java
+++ b/src/main/java/com/equip/equiprental/member/controller/DepartmentController.java
@@ -25,7 +25,7 @@ public class DepartmentController implements ResponseController {
     @GetMapping("")
     public ResponseEntity<ResponseDto<List<DepartmentDto>>> getAll() {
         String traceId = RequestTraceIdInterceptor.getTraceId();
-        log.info("[회원 가입 요청 API] TraceId={}", traceId);
+        log.info("모든 부서명 조회 요청 API] TraceId={}", traceId);
 
         List<DepartmentDto> result = departmentService.getDepartmentList();
         return makeResponseEntity(traceId, HttpStatus.OK, null, "모든 부서명 조회 성공", result);

--- a/src/main/java/com/equip/equiprental/rental/repository/dsl/RentalItemQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/rental/repository/dsl/RentalItemQRepoImpl.java
@@ -38,12 +38,12 @@ public class RentalItemQRepoImpl implements RentalItemQRepo{
             builder.and(i.rental.member.name.containsIgnoreCase(paramDto.getMemberName()));
         }
 
-        if (paramDto.getCategoryEnum() != null) {
-            builder.and(i.rental.equipment.category.eq(paramDto.getCategoryEnum()));
+        if (paramDto.getCategoryId() != null) {
+            builder.and(i.rental.equipment.subCategory.category.categoryId.eq(paramDto.getCategoryId()));
         }
 
-        if (paramDto.getSubCategory() != null && !paramDto.getSubCategory().isEmpty()) {
-            builder.and(i.rental.equipment.subCategory.eq(paramDto.getSubCategory()));
+        if (paramDto.getSubCategoryId() != null) {
+            builder.and(i.rental.equipment.subCategory.subCategoryId.eq(paramDto.getSubCategoryId()));
         }
 
         List<AdminRentalItemDto> results = queryFactory
@@ -51,8 +51,8 @@ public class RentalItemQRepoImpl implements RentalItemQRepo{
                         i.rentalItemId,
                         i.rental.rentalId,
                         f.filePath,
-                        i.rental.equipment.category.stringValue(),
-                        i.rental.equipment.subCategory,
+                        i.rental.equipment.subCategory.category.label,
+                        i.rental.equipment.subCategory.label,
                         i.rental.equipment.model,
                         i.equipmentItem.serialNumber,
                         i.rental.member.name,
@@ -91,12 +91,12 @@ public class RentalItemQRepoImpl implements RentalItemQRepo{
 
         builder.and(i.rental.member.memberId.eq(memberId));
 
-        if (paramDto.getCategoryEnum() != null) {
-            builder.and(i.rental.equipment.category.eq(paramDto.getCategoryEnum()));
+        if (paramDto.getCategoryId() != null) {
+            builder.and(i.rental.equipment.subCategory.category.categoryId.eq(paramDto.getCategoryId()));
         }
 
-        if (paramDto.getSubCategory() != null && !paramDto.getSubCategory().isEmpty()) {
-            builder.and(i.rental.equipment.subCategory.eq(paramDto.getSubCategory()));
+        if (paramDto.getSubCategoryId() != null) {
+            builder.and(i.rental.equipment.subCategory.subCategoryId.eq(paramDto.getSubCategoryId()));
         }
 
         if (paramDto.getModel() != null && !paramDto.getModel().isEmpty()) {
@@ -108,8 +108,8 @@ public class RentalItemQRepoImpl implements RentalItemQRepo{
                         i.rentalItemId,
                         i.rental.rentalId,
                         f.filePath,
-                        i.rental.equipment.category.stringValue(),
-                        i.rental.equipment.subCategory,
+                        i.rental.equipment.subCategory.category.label,
+                        i.rental.equipment.subCategory.label,
                         i.rental.equipment.model,
                         i.equipmentItem.serialNumber,
                         i.startDate,

--- a/src/main/java/com/equip/equiprental/rental/repository/dsl/RentalQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/rental/repository/dsl/RentalQRepoImpl.java
@@ -38,12 +38,12 @@ public class RentalQRepoImpl implements RentalQRepo{
             builder.and(r.member.name.containsIgnoreCase(paramDto.getMemberName()));
         }
 
-        if (paramDto.getCategoryEnum() != null) {
-            builder.and(r.equipment.category.eq(paramDto.getCategoryEnum()));
+        if (paramDto.getCategoryId() != null) {
+            builder.and(r.equipment.subCategory.category.categoryId.eq(paramDto.getCategoryId()));
         }
 
-        if (paramDto.getSubCategory() != null && !paramDto.getSubCategory().isEmpty()) {
-            builder.and(r.equipment.subCategory.eq(paramDto.getSubCategory()));
+        if (paramDto.getSubCategoryId() != null) {
+            builder.and(r.equipment.subCategory.subCategoryId.eq(paramDto.getSubCategoryId()));
         }
 
         List<AdminRentalDto> content = queryFactory
@@ -58,8 +58,8 @@ public class RentalQRepoImpl implements RentalQRepo{
                         r.member.memberId,
                         r.member.name,
                         r.member.department,
-                        r.equipment.category.stringValue(),
-                        r.equipment.subCategory,
+                        r.equipment.subCategory.category.label,
+                        r.equipment.subCategory.label,
                         r.equipment.model
                 ))
                 .from(r)
@@ -88,12 +88,12 @@ public class RentalQRepoImpl implements RentalQRepo{
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(r.member.memberId.eq(memberId));
 
-        if (paramDto.getCategoryEnum() != null) {
-            builder.and(r.equipment.category.eq(paramDto.getCategoryEnum()));
+        if (paramDto.getCategoryId() != null) {
+            builder.and(r.equipment.subCategory.category.categoryId.eq(paramDto.getCategoryId()));
         }
 
-        if (paramDto.getSubCategory() != null && !paramDto.getSubCategory().isEmpty()) {
-            builder.and(r.equipment.subCategory.eq(paramDto.getSubCategory()));
+        if (paramDto.getSubCategoryId() != null) {
+            builder.and(r.equipment.subCategory.subCategoryId.eq(paramDto.getSubCategoryId()));
         }
 
         if (paramDto.getRentalStatus() != null && !paramDto.getRentalStatus().isEmpty()) {
@@ -104,8 +104,8 @@ public class RentalQRepoImpl implements RentalQRepo{
                 .select(Projections.constructor(UserRentalDto.class,
                         r.rentalId,
                         r.equipment.model,
-                        r.equipment.category.stringValue(),
-                        r.equipment.subCategory,
+                        r.equipment.subCategory.category.label,
+                        r.equipment.subCategory.label,
                         f.filePath,
                         r.requestStartDate,
                         r.requestEndDate,

--- a/src/main/java/com/equip/equiprental/scope/domain/ManagerScope.java
+++ b/src/main/java/com/equip/equiprental/scope/domain/ManagerScope.java
@@ -1,6 +1,5 @@
 package com.equip.equiprental.scope.domain;
 
-import com.equip.equiprental.equipment.domain.EquipmentCategory;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/equip/equiprental/scope/service/ManagerScopeService.java
+++ b/src/main/java/com/equip/equiprental/scope/service/ManagerScopeService.java
@@ -1,6 +1,5 @@
 package com.equip.equiprental.scope.service;
 
-import com.equip.equiprental.equipment.domain.EquipmentCategory;
 import com.equip.equiprental.equipment.repository.EquipmentItemRepository;
 import com.equip.equiprental.equipment.repository.EquipmentRepository;
 import com.equip.equiprental.scope.repository.ManagerScopeRepository;

--- a/src/main/java/com/equip/equiprental/scope/service/ManagerScopeService.java
+++ b/src/main/java/com/equip/equiprental/scope/service/ManagerScopeService.java
@@ -1,5 +1,6 @@
 package com.equip.equiprental.scope.service;
 
+import com.equip.equiprental.equipment.domain.Category;
 import com.equip.equiprental.equipment.repository.EquipmentItemRepository;
 import com.equip.equiprental.equipment.repository.EquipmentRepository;
 import com.equip.equiprental.scope.repository.ManagerScopeRepository;
@@ -17,12 +18,12 @@ public class ManagerScopeService {
      * Equipment 단위 권한 체크
      */
     public boolean canAccessEquipment(Long equipmentId, Long managerId) {
-        EquipmentCategory categoryEnum = equipmentRepository.findCategoryByEquipmentId(equipmentId);
-        if (categoryEnum == null) return false;
+        Category category = equipmentRepository.findCategoryByEquipmentId(equipmentId);
+        if (category == null) return false;
 
         // enum -> String
-        String category = categoryEnum.name();
-        return managerScopeRepository.existsByManagerIdAndCategory(managerId, category);
+        String label = category.getLabel();
+        return managerScopeRepository.existsByManagerIdAndCategory(managerId, label);
     }
 
     /**

--- a/src/main/resources/static/css/equipment/adminEquipmentList.css
+++ b/src/main/resources/static/css/equipment/adminEquipmentList.css
@@ -1,0 +1,10 @@
+.filter-card {
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+#equipment-list {
+    padding-top: 40px;
+    margin-top: 20px;
+}

--- a/src/main/resources/static/css/equipment/equipmentList.css
+++ b/src/main/resources/static/css/equipment/equipmentList.css
@@ -1,0 +1,29 @@
+#sub-category-filters {
+    margin-top: 0.5rem;
+    display: none; /* 초기 숨김 */
+}
+#sub-category-filters.active {
+    display: block;
+}
+
+.btn-check:checked + .btn {
+    background-color: #0d6efd;
+    color: white;
+    transition: all 0.2s;
+}
+.btn {
+    border-radius: 0.5rem; /* 부드러운 모서리 */
+    margin-right: 0.25rem;
+    margin-bottom: 0.25rem;
+}
+
+.filter-card {
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+#equipment-list {
+    padding-top: 40px;
+    margin-top: 20px;
+}

--- a/src/main/resources/static/css/equipment/equipmentList.css
+++ b/src/main/resources/static/css/equipment/equipmentList.css
@@ -1,22 +1,3 @@
-#sub-category-filters {
-    margin-top: 0.5rem;
-    display: none; /* 초기 숨김 */
-}
-#sub-category-filters.active {
-    display: block;
-}
-
-.btn-check:checked + .btn {
-    background-color: #0d6efd;
-    color: white;
-    transition: all 0.2s;
-}
-.btn {
-    border-radius: 0.5rem; /* 부드러운 모서리 */
-    margin-right: 0.25rem;
-    margin-bottom: 0.25rem;
-}
-
 .filter-card {
     font-weight: 500;
     margin-bottom: 0.5rem;

--- a/src/main/resources/static/js/common/common.js
+++ b/src/main/resources/static/js/common/common.js
@@ -6,72 +6,6 @@ function handleServerError(jqXHR) {
     }
 }
 
-function renderFilter(containerId, config, onChange) {
-    const container = $("#" + containerId);
-    container.empty(); // 초기화
-
-    $.each(config, function(key, value) {
-        const group = $("<div>").addClass("mb-3");
-
-        const label = $("<label>").addClass("form-label").text(value.label);
-        group.append(label);
-
-        const btnGroup = $("<div>")
-            .addClass("btn-group w-100")
-            .attr("role", "group");
-
-        $.each(value.options, function(_, opt) {
-            const inputId = key + "-" + opt;
-            const input = $("<input>")
-                .attr("type", value.type)
-                .addClass("btn-check")
-                .attr("name", key)
-                .attr("id", inputId)
-                .val(opt === "전체" ? "" : opt);
-
-            // "전체"는 항상 기본 checked
-            if (opt === "전체") {
-                input.prop("checked", true);
-            }
-
-            // UI에 표시할 label
-            let displayText = opt;
-            if (key === "category") {
-                displayText = categoryLabelMap[opt] || opt;
-            } else if (key === "subCategory") {
-                displayText = subCategoryMap?.[opt] || opt;
-            } else if (key === "status") {
-                displayText = statusLabelMap?.[opt] || opt;
-            }
-
-            const button = $("<label>")
-                .addClass("btn btn-outline-primary")
-                .attr("for", inputId)
-                .text(displayText );
-
-            input.on("change", function() {
-                onChange(getFilterValues(config));
-            });
-
-            btnGroup.append(input, button);
-        });
-
-        group.append(btnGroup);
-        container.append(group);
-    });
-}
-
-function getFilterValues(config) {
-    // values 라는 빈 객체 생성
-    const values = {};
-    $.each(config, function(key) {
-        const selected = $(`input[name="${key}"]:checked`);
-        values[key] = selected.length ? selected.val() : "";
-    });
-    // 빈 객체에 config key/value 담아서 반환
-    return values;
-}
-
 // 페이징 렌더링
 function renderPagination(containerId, pageInfo, onPageChange) {
     const container = $("#" + containerId);
@@ -118,6 +52,17 @@ function renderPagination(containerId, pageInfo, onPageChange) {
 
     container.append(pagination);
 }
+
+// function getFilterValues(config) {
+//     // values 라는 빈 객체 생성
+//     const values = {};
+//     $.each(config, function(key) {
+//         const selected = $(`input[name="${key}"]:checked`);
+//         values[key] = selected.length ? selected.val() : "";
+//     });
+//     // 빈 객체에 config key/value 담아서 반환
+//     return values;
+// }
 
 function getCurrentPage(containerId) {
     const activeLink = $(`#${containerId} .page-item.active a`);

--- a/src/main/resources/static/js/equipment/admin/adminEquipmentList.js
+++ b/src/main/resources/static/js/equipment/admin/adminEquipmentList.js
@@ -1,93 +1,5 @@
 let currentEquipmentId = null;
 
-// 필터 설정 예시
-const filterConfig = {
-    category: {
-        label: "카테고리",
-        type: "radio",
-        options: [
-            "전체",
-            "OFFICE_SUPPLIES",
-            "ELECTRONICS",
-            "FURNITURE",
-            "TOOLS",
-            "SAFETY_EQUIPMENT"
-        ]
-    },
-
-    subCategory: {
-        label: "서브카테고리",
-        type: "radio",
-        options: ["전체"] // 초기값은 전체, 카테고리 선택 시 동적으로 바뀜
-    }
-};
-
-const categoryLabelMap = {
-    "전체": "전체",
-    "OFFICE_SUPPLIES": "사무용품",
-    "ELECTRONICS": "전자기기",
-    "FURNITURE": "가구",
-    "TOOLS": "공구",
-    "SAFETY_EQUIPMENT": "안전장비"
-};
-
-const subCategoryMap = {
-    OFFICE_SUPPLIES: [
-        "문서 파쇄기",
-        "라벨프린터",
-        "프로젝트 보드"
-    ],
-    ELECTRONICS: [
-        "노트북",
-        "태블릿",
-        "프로젝터",
-        "모니터",
-        "프린터",
-        "카메라/캠코더",
-        "오디오장비(스피커/마이크)",
-        "외장저장장치(SSD/HDD)"
-    ],
-    FURNITURE: [
-        "사무용 의자",
-        "책상/테이블",
-        "서랍장/캐비닛",
-        "이동식 파티션",
-        "화이트보드"
-    ],
-    TOOLS: [
-        "전동공구(드릴, 그라인더)",
-        "수공구(망치, 드라이버)",
-        "측정도구(레이저측정기, 콤파스)",
-        "납땜장비"
-    ],
-    SAFETY_EQUIPMENT: [
-        "안전모",
-        "안전화",
-        "보호안경/귀마개",
-        "방진마스크",
-        "소화기/응급키트"
-    ]
-};
-
-// pageshow 이벤트 활용: 뒤로가기/앞으로가기 시에도 실행
-window.addEventListener("pageshow", function(event) {
-    // 필터 강제 초기화
-    $("input[name='category']").prop("checked", false);
-    $("input[name='category'][value='전체']").prop("checked", true);
-
-    $("input[name='subCategory']").prop("checked", false);
-    $("input[name='subCategory'][value='전체']").prop("checked", true);
-
-    // 검색어 초기화
-    $("#equipment-search").val("");
-
-    // 필터 렌더링
-    renderFilter("equipment-filters", filterConfig, onFilterChange);
-
-    // 초기 장비 리스트 조회
-    fetchEquipment();
-});
-
 // 검색 이벤트 등록
 $(document).ready(function() {
     $("#equipment-search").on("input", function() {
@@ -96,14 +8,111 @@ $(document).ready(function() {
     });
 });
 
+// pageshow 이벤트 활용: 뒤로가기/앞으로가기 시에도 실행
+window.addEventListener("pageshow", async function (event) {
+    // 필터 초기화
+    $("input[name='category']").prop("checked", false);
+    $("input[name='subCategory']").prop("checked", false);
+    $("#equipment-search").val("");
+
+    // 필터 구성 가져오기
+    window.filterConfig = await fetchFilterConfig();
+    if (filterConfig) {
+        // 카테고리만 먼저 렌더링
+        renderFilter("category-filters", {category: filterConfig.category}, onFilterChange);
+        // 서브카테고리는 초기엔 옵션이 없으면 숨김
+        $("#sub-category-filters").hide();
+
+        fetchEquipment();
+    }
+});
+
+// 필터 구성 가져오기
+async function fetchFilterConfig() {
+    try {
+        const categoryResp = await $.getJSON('/api/v1/categories');
+        const categories = categoryResp.data;
+
+        return {
+            category: {
+                label: "카테고리",
+                type: "radio",
+                options: [
+                    { id: null, label: "전체" }, // 전체 추가
+                    ...categories.map(c => ({ id: c.categoryId, label: c.label }))
+                ]
+            },
+            subCategory: {
+                label: "서브카테고리",
+                type: "radio",
+                options: []
+            }
+        };
+    } catch (e) {
+        console.error("필터 구성 불러오기 실패", e);
+        return null;
+    }
+}
+
+// 필터 렌더링
+function renderFilter(containerId, config, onChange) {
+    const container = $("#" + containerId);
+    container.empty();
+
+    Object.entries(config).forEach(([key, value]) => {
+        if (!value.options || value.options.length === 0) {
+            container.hide();
+            return;
+        } else {
+            container.show();
+        }
+
+        const group = $("<div>").addClass("mb-3");
+
+        const btnGroup = $("<div>").addClass("btn-group w-100").attr("role", "group");
+
+        value.options.forEach(opt => {
+            const inputId = key + "-" + (opt.id ?? opt.label);
+            const input = $("<input>")
+                .attr("type", value.type)
+                .addClass("btn-check")
+                .attr("name", key)
+                .attr("id", inputId)
+                .val(opt.id ?? "")
+                .prop("checked", opt.id === null); // 전체 체크
+
+            const button = $("<label>")
+                .addClass("btn btn-outline-primary")
+                .attr("for", inputId)
+                .text(opt.label);
+
+            input.on("change", () => onChange(getFilterValues(filterConfig)));
+
+            btnGroup.append(input, button);
+        });
+
+        group.append(btnGroup);
+        container.append(group);
+    });
+}
+
+// 현재 필터 값 가져오기
+function getFilterValues(config) {
+    const values = {};
+    Object.keys(config).forEach(key => {
+        const selected = $(`input[name="${key}"]:checked`);
+        values[key] = selected.length ? selected.val() : "";
+    });
+    return values;
+}
 
 // 필터 변경 시 동작
-function onFilterChange() {
+async function onFilterChange() {
     // 현재 선택된 카테고리 값
-    const category = getFilterValues(filterConfig).category;
+    const categoryId = getFilterValues(filterConfig).category;
 
     // 서브카테고리 갱신
-    updateSubCategoryOptions(category);
+    await updateSubCategoryOptions(categoryId);
 
     // 최신 filterConfig 값으로 fetch
     const filters = getFilterValues(filterConfig);
@@ -112,20 +121,27 @@ function onFilterChange() {
 
 
 // 서브카테고리 업데이트
-function updateSubCategoryOptions(parentCategory) {
-    const options = subCategoryMap[parentCategory] || [];
+async function updateSubCategoryOptions(parentCategoryId) {
+    let options = [];
+    if (parentCategoryId) {
+        try {
+            const response = await $.getJSON(`/api/v1/categories/${parentCategoryId}/sub-categories`);
+            options = response.data.map(sc => ({ id: sc.subCategoryId, label: sc.label }));
+            options.unshift({ id: null, label: "전체" });
+        } catch (e) {
+            console.error("서브카테고리 불러오기 실패", e);
+        }
+    }
 
     filterConfig.subCategory.options = options;
 
-    const container = $("#sub-category-filters");
-    container.empty();
-    renderFilter("sub-category-filters", {
-        subCategory: {
-            type: "radio",
-            options: options
-        }
-    }, (values) => {
-        // category 필터도 함께 포함
+    if (options.length > 1) {
+        $("#sub-category-filters").addClass("active"); // 옵션이 있으면 표시
+    } else {
+        $("#sub-category-filters").removeClass("active"); // 옵션 없으면 숨김
+    }
+
+    renderFilter("sub-category-filters", { subCategory: { type: "radio", options } }, (values) => {
         const combinedFilters = {
             category: getFilterValues(filterConfig).category,
             subCategory: values.subCategory
@@ -140,8 +156,8 @@ function fetchEquipment(filters={}) {
     const filterValues = filters || getFilterValues(filterConfig);
     const modelSearch = $("#equipment-search").val();
     const params = {
-        category: filterValues.category || null,
-        subCategory: filterValues.subCategory || null,
+        categoryId: filterValues.category || null,
+        subCategoryId: filterValues.subCategory || null,
         model: modelSearch || null
     };
 
@@ -199,7 +215,7 @@ function renderEquipmentList(list) {
                                 <h6 class="card-title mb-1">
                                     <p class="mb-0 fw-bold">${equip.model}</p>
                                     <p class="mb-0 text-muted">
-                                        ${categoryLabelMap[equip.category]} / ${equip.subCategory}
+                                        ${equip.category} / ${equip.subCategory}
                                     </p>
                                 </h6>
                                 <p class="card-text mb-1">사용 가능 재고: ${equip.availableStock}</p>

--- a/src/main/resources/static/js/equipment/admin/equipmentRegistration.js
+++ b/src/main/resources/static/js/equipment/admin/equipmentRegistration.js
@@ -1,53 +1,26 @@
-const subCategoryMap = {
-    OFFICE_SUPPLIES: [
-        "문서 파쇄기",
-        "라벨프린터",
-        "프로젝트 보드"
-    ],
-    ELECTRONICS: [
-        "노트북",
-        "태블릿",
-        "프로젝터",
-        "모니터",
-        "프린터",
-        "카메라/캠코더",
-        "오디오장비(스피커/마이크)",
-        "외장저장장치(SSD/HDD)"
-    ],
-    FURNITURE: [
-        "사무용 의자",
-        "책상/테이블",
-        "서랍장/캐비닛",
-        "이동식 파티션",
-        "화이트보드"
-    ],
-    TOOLS: [
-        "전동공구(드릴, 그라인더)",
-        "수공구(망치, 드라이버)",
-        "측정도구(레이저측정기, 콤파스)",
-        "납땜장비"
-    ],
-    SAFETY_EQUIPMENT: [
-        "안전모",
-        "안전화",
-        "보호안경/귀마개",
-        "방진마스크",
-        "소화기/응급키트"
-    ]
-};
-
 $(document).ready(function () {
-    // 카테고리 변경 시 서브카테고리 옵션 갱신
-    $('#equipmentCategory').on('change', function() {
-        const category = $(this).val();
-        const $subCategory = $('#equipmentSubCategory');
-        $subCategory.empty().append('<option value="">선택</option>');
+    const category = $('#equipmentCategory');
+    const subCategory = $('#equipmentSubCategory');
 
-        if (category && subCategoryMap[category]) {
-            subCategoryMap[category].forEach(sub => {
-                $subCategory.append(`<option value="${sub}">${sub}</option>`);
+    // 카테고리 전체 조회
+    $.getJSON('/api/v1/categories', function(categories) {
+        categories.data.forEach(cat => {
+            category.append(`<option value="${cat.categoryId}">${cat.label}</option>`);
+        });
+    });
+
+    // 카테고리 변경 시 서브카테고리 조회
+    category.on('change', function() {
+        const categoryId = $(this).val();
+        subCategory.empty().append('<option value="">선택</option>');
+
+        if (!categoryId) return;
+
+        $.getJSON(`/api/v1/categories/${categoryId}/sub-categories`, function(subCategories) {
+            subCategories.data.forEach(sub => {
+                subCategory.append(`<option value="${sub.subCategoryId}">${sub.label}</option>`);
             });
-        }
+        });
     });
 
     // 파일 선택 시 미리보기 리스트 렌더링
@@ -95,13 +68,12 @@ $(document).ready(function () {
 });
 
 function registerEquipment() {
-    const $category = $('#equipmentCategory');
-    const $subCategory = $('#equipmentSubCategory');
-    const $model = $('#model');
-    const $stock = $('#stock');
+    const subCategoryId = $('#equipmentSubCategory').val();
+    const model = $('#model').val();
+    const stock = $('#stock').val();
     const $files = $('#files');
 
-    if (!$category.val() || !$subCategory.val() || !$model.val() || !$stock.val()) {
+    if (!subCategoryId || !model || !stock) {
         alert('모든 필드를 입력해주세요.');
         return;
     }
@@ -110,12 +82,11 @@ function registerEquipment() {
 
     // JSON 데이터
     const data = {
-        category: $category.val(),
-        subCategory: $subCategory.val(),
-        model: $model.val(),
-        stock: $stock.val()
+        subCategoryId: subCategoryId,
+        model: model,
+        stock: stock
     };
-
+    console.log(data);
     // JSON을 Blob으로 만들어서 FormData에 추가
     const jsonBlob = new Blob([JSON.stringify(data)], { type: "application/json" });
     formData.append("data", jsonBlob);

--- a/src/main/resources/static/js/equipment/equipmentList.js
+++ b/src/main/resources/static/js/equipment/equipmentList.js
@@ -1,92 +1,3 @@
-// 필터 설정 예시
-const filterConfig = {
-    category: {
-        label: "카테고리",
-        type: "radio",
-        options: [
-            "전체",
-            "OFFICE_SUPPLIES",
-            "ELECTRONICS",
-            "FURNITURE",
-            "TOOLS",
-            "SAFETY_EQUIPMENT"
-        ]
-    },
-
-    subCategory: {
-        label: "서브카테고리",
-        type: "radio",
-        options: ["전체"] // 초기값은 전체, 카테고리 선택 시 동적으로 바뀜
-    }
-};
-
-
-const categoryLabelMap = {
-    "전체": "전체",
-    "OFFICE_SUPPLIES": "사무용품",
-    "ELECTRONICS": "전자기기",
-    "FURNITURE": "가구",
-    "TOOLS": "공구",
-    "SAFETY_EQUIPMENT": "안전장비"
-};
-
-const subCategoryMap = {
-    OFFICE_SUPPLIES: [
-        "문서 파쇄기",
-        "라벨프린터",
-        "프로젝트 보드"
-    ],
-    ELECTRONICS: [
-        "노트북",
-        "태블릿",
-        "프로젝터",
-        "모니터",
-        "프린터",
-        "카메라/캠코더",
-        "오디오장비(스피커/마이크)",
-        "외장저장장치(SSD/HDD)"
-    ],
-    FURNITURE: [
-        "사무용 의자",
-        "책상/테이블",
-        "서랍장/캐비닛",
-        "이동식 파티션",
-        "화이트보드"
-    ],
-    TOOLS: [
-        "전동공구(드릴, 그라인더)",
-        "수공구(망치, 드라이버)",
-        "측정도구(레이저측정기, 콤파스)",
-        "납땜장비"
-    ],
-    SAFETY_EQUIPMENT: [
-        "안전모",
-        "안전화",
-        "보호안경/귀마개",
-        "방진마스크",
-        "소화기/응급키트"
-    ]
-};
-
-// pageshow 이벤트 활용: 뒤로가기/앞으로가기 시에도 실행
-window.addEventListener("pageshow", function(event) {
-    // 필터 강제 초기화
-    $("input[name='category']").prop("checked", false);
-    $("input[name='category'][value='전체']").prop("checked", true);
-
-    $("input[name='subCategory']").prop("checked", false);
-    $("input[name='subCategory'][value='전체']").prop("checked", true);
-
-    // 검색어 초기화
-    $("#equipment-search").val("");
-
-    // 필터 렌더링
-    renderFilter("equipment-filters", filterConfig, onFilterChange);
-
-    // 초기 장비 리스트 조회
-    fetchEquipment();
-});
-
 $(document).ready(function() {
     // 검색 이벤트
     $("#equipment-search").on("input", function() {
@@ -95,35 +6,134 @@ $(document).ready(function() {
     });
 });
 
-// 필터 변경 시 동작
-function onFilterChange(values) {
-    // 현재 선택된 카테고리 값
-    const category = getFilterValues(filterConfig).category;
+// 페이지가 보여질 때 초기화
+window.addEventListener("pageshow", async function () {
+    // 필터 초기화
+    $("input[name='category']").prop("checked", false);
+    $("input[name='subCategory']").prop("checked", false);
+    $("#equipment-search").val("");
 
-    // 서브카테고리 갱신
-    updateSubCategoryOptions(category);
+    // 필터 구성 가져오기
+    window.filterConfig = await fetchFilterConfig();
+    if (filterConfig) {
+        // 카테고리만 먼저 렌더링
+        renderFilter("category-filters", { category: filterConfig.category }, onFilterChange);
+        // 서브카테고리는 초기엔 옵션이 없으면 숨김
+        $("#sub-category-filters").hide();
 
-    // 최신 filterConfig 값으로 fetch
-    const filters = getFilterValues(filterConfig);
-    fetchEquipment(filters);
+        fetchEquipment();
+    }
+});
+
+// 필터 구성 가져오기
+async function fetchFilterConfig() {
+    try {
+        const categoryResp = await $.getJSON('/api/v1/categories');
+        const categories = categoryResp.data;
+
+        return {
+            category: {
+                label: "카테고리",
+                type: "radio",
+                options: [
+                    { id: null, label: "전체" }, // 전체 추가
+                    ...categories.map(c => ({ id: c.categoryId, label: c.label }))
+                ]
+            },
+            subCategory: {
+                label: "서브카테고리",
+                type: "radio",
+                options: []
+            }
+        };
+    } catch (e) {
+        console.error("필터 구성 불러오기 실패", e);
+        return null;
+    }
 }
 
+// 필터 렌더링
+function renderFilter(containerId, config, onChange) {
+    const container = $("#" + containerId);
+    container.empty();
+
+    Object.entries(config).forEach(([key, value]) => {
+        if (!value.options || value.options.length === 0) {
+            container.hide();
+            return;
+        } else {
+            container.show();
+        }
+
+        const group = $("<div>").addClass("mb-3");
+
+        const btnGroup = $("<div>").addClass("btn-group w-100").attr("role", "group");
+
+        value.options.forEach(opt => {
+            const inputId = key + "-" + (opt.id ?? opt.label);
+            const input = $("<input>")
+                .attr("type", value.type)
+                .addClass("btn-check")
+                .attr("name", key)
+                .attr("id", inputId)
+                .val(opt.id ?? "")
+                .prop("checked", opt.id === null); // 전체 체크
+
+            const button = $("<label>")
+                .addClass("btn btn-outline-primary")
+                .attr("for", inputId)
+                .text(opt.label);
+
+            input.on("change", () => onChange(getFilterValues(filterConfig)));
+
+            btnGroup.append(input, button);
+        });
+
+        group.append(btnGroup);
+        container.append(group);
+    });
+}
+
+// 현재 필터 값 가져오기
+function getFilterValues(config) {
+    const values = {};
+    Object.keys(config).forEach(key => {
+        const selected = $(`input[name="${key}"]:checked`);
+        values[key] = selected.length ? selected.val() : "";
+    });
+    return values;
+}
+
+// 필터 변경 시
+async function onFilterChange() {
+    const categoryId = getFilterValues(filterConfig).category;
+    await updateSubCategoryOptions(categoryId);
+
+    fetchEquipment(getFilterValues(filterConfig));
+}
 
 // 서브카테고리 업데이트
-function updateSubCategoryOptions(parentCategory) {
-    const options = subCategoryMap[parentCategory] || [];
+async function updateSubCategoryOptions(parentCategoryId) {
+    let options = [];
+    if (parentCategoryId) {
+        try {
+            const response = await $.getJSON(`/api/v1/categories/${parentCategoryId}/sub-categories`);
+            options = response.data.map(sc => ({ id: sc.subCategoryId, label: sc.label }));
+            options.unshift({ id: null, label: "전체" });
+        } catch (e) {
+            console.error("서브카테고리 불러오기 실패", e);
+        }
+    }
 
     filterConfig.subCategory.options = options;
 
-    const container = $("#sub-category-filters");
-    container.empty();
-    renderFilter("sub-category-filters", {
-        subCategory: {
-            type: "radio",
-            options: options
-        }
-    }, (values) => {
-        // category 필터도 함께 포함
+    if (options.length > 1) {
+        $("#sub-category-filters").addClass("active"); // 옵션이 있으면 표시
+    } else {
+        $("#sub-category-filters").removeClass("active"); // 옵션 없으면 숨김
+    }
+
+    renderFilter("sub-category-filters", { subCategory: { type: "radio", options } }, (values) => {
         const combinedFilters = {
             category: getFilterValues(filterConfig).category,
             subCategory: values.subCategory
@@ -132,21 +142,18 @@ function updateSubCategoryOptions(parentCategory) {
     });
 }
 
-// 장비 리스트 조회 함수
+// 장비 리스트 조회
 function fetchEquipment(filters={}) {
-    // 필터 통합
     const filterValues = filters || getFilterValues(filterConfig);
     const modelSearch = $("#equipment-search").val();
+
     const params = {
-        category: filterValues.category || null,
-        subCategory: filterValues.subCategory || null,
+        categoryId: filterValues.category || null,
+        subCategoryId: filterValues.subCategory || null,
         model: modelSearch || null
     };
 
-    // page가 있으면 추가
-    if (filterValues.page) {
-        params.page = filterValues.page;
-    }
+    if (filterValues.page) params.page = filterValues.page;
 
     $.ajax({
         url: "/api/v1/equipments",
@@ -165,7 +172,6 @@ function fetchEquipment(filters={}) {
     }).fail(handleServerError);
 }
 
-
 // 장비 리스트 렌더링
 function renderEquipmentList(list) {
     const container = $("#equipment-list");
@@ -183,26 +189,20 @@ function renderEquipmentList(list) {
             <div class="col-md-6 mb-3">
                 <div class="card shadow-sm h-100">
                     <div class="row g-0 align-items-center">
-                        <!-- 이미지 영역 -->
                         <div class="col-auto bg-light d-flex align-items-center justify-content-center" style="width:120px; height:120px;">
                             <img src="${equip.imageUrl}"  
                                  style="max-width:100%; max-height:100%; object-fit:contain;" 
                                  alt="대표 이미지"
                                  class="p-1 rounded-start">
                         </div>
-
-                        <!-- 텍스트 + 버튼 영역 -->
                         <div class="col d-flex align-items-center justify-content-between">
                             <div class="card-body p-2">
                                 <h6 class="card-title mb-1 fw-bold">${equip.model}</h6>
-                                <p class="mb-0 text-muted">
-                                    ${categoryLabelMap[equip.category]} / ${equip.subCategory || '-'}
-                                </p>
+                                <p class="mb-0 text-muted">${equip.category} / ${equip.subCategory || '-'}</p>
                                 <p class="card-text mb-1">재고: ${equip.availableStock}</p>
                             </div>
                             <div class="pe-2">
-                                <button class="btn btn-outline-primary btn-sm rental-btn" 
-                                        data-id="${equip.equipmentId}">
+                                <button class="btn btn-outline-primary btn-sm rental-btn" data-id="${equip.equipmentId}">
                                     <i class="bi bi-box-seam"></i> 대여 신청
                                 </button>
                             </div>
@@ -214,7 +214,6 @@ function renderEquipmentList(list) {
 
         row.append(card);
 
-        // 2개마다 row 추가하고 새로운 row 시작
         if ((index + 1) % 2 === 0 || index === list.length - 1) {
             container.append(row);
             row = $('<div class="row"></div>');
@@ -222,18 +221,16 @@ function renderEquipmentList(list) {
     });
 }
 
+// 모달 이벤트
 $(document).on("click", ".rental-btn", function() {
     const equipmentId = $(this).data("id");
     $("#modalEquipmentId").val(equipmentId);
 
-    // 오늘 날짜를 기본값으로 설정
     const today = new Date().toISOString().split("T")[0];
     $("#rentalStartDate").val(today);
     $("#rentalEndDate").val(today);
 
-    // 모달 띄우기
-    const rentalModal = new bootstrap.Modal(document.getElementById('rentalModal'));
-    rentalModal.show();
+    new bootstrap.Modal(document.getElementById('rentalModal')).show();
 });
 
 $("#submitRental").on("click", function() {
@@ -248,13 +245,7 @@ $("#submitRental").on("click", function() {
         return;
     }
 
-    const payload = {
-        equipmentId: parseInt(equipmentId, 10),
-        quantity,
-        startDate,
-        endDate,
-        rentalReason
-    };
+    const payload = { equipmentId: parseInt(equipmentId, 10), quantity, startDate, endDate, rentalReason };
 
     $.ajax({
         url: "/api/v1/rentals",
@@ -263,17 +254,13 @@ $("#submitRental").on("click", function() {
         data: JSON.stringify(payload)
     }).done(function(response) {
         alert(response.message);
-        $("#rentalModal").modal("hide"); // jQuery 방식
+        $("#rentalModal").modal("hide");
 
-        // 현재 필터 상태를 그대로 사용해서 리스트만 갱신
-        const currentFilters = getFilterValues(filterConfig);
-        fetchEquipment(currentFilters);
-    }).fail(function(xhr) {
-        handleServerError(xhr);
-    });
+        fetchEquipment(getFilterValues(filterConfig));
+    }).fail(handleServerError);
 });
 
 $("#rentalModal").on("hidden.bs.modal", function () {
-    $("#rentalForm")[0].reset();      // form 요소 초기화
-    $("#modalEquipmentId").val("");    // hidden input 초기화
+    $("#rentalForm")[0].reset();
+    $("#modalEquipmentId").val("");
 });

--- a/src/main/resources/templates/equipment/admin/adminEquipmentList.html
+++ b/src/main/resources/templates/equipment/admin/adminEquipmentList.html
@@ -8,6 +8,7 @@
     <title>EquipRental - 장비 조회</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="/css/common/common.css">
+    <link rel="stylesheet" href="/css/equipment/adminEquipmentList.css">
 </head>
 <body>
 <div class="wrapper">
@@ -15,13 +16,13 @@
         {{> common/adminSidebar }}
         <main class="content">
             <div class="container-fluid mt-5">
-                <h2>장비 조회</h2>
                 <!-- 필터 영역 -->
-                <div id="equipment-filters" class="mt-3"></div>
-                <div id="sub-category-filters"></div>
+                <div class="filter-card p-3 mb-3 border rounded shadow-sm">
+                    <div id="category-filters" class="mt-3"></div>
+                    <div id="sub-category-filters" class="mt-3 mb-3"></div>
 
-                <!-- 검색창 -->
-                <div class="mb-3">
+                    <!-- 검색창 -->
+                    <label for="equipment-search"></label>
                     <input type="text" id="equipment-search" class="form-control" placeholder="모델 검색">
                 </div>
 
@@ -32,7 +33,7 @@
 
                 <!-- 페이징 영역 -->
                 <nav>
-                    <div id="pagination"></div>
+                    <div id="pagination" class="mt-4"></div>
                 </nav>
             </div>
 

--- a/src/main/resources/templates/equipment/admin/equipmentRegistration.html
+++ b/src/main/resources/templates/equipment/admin/equipmentRegistration.html
@@ -25,11 +25,6 @@
                         <div class="col-sm-4">
                             <select class="form-select" id="equipmentCategory" required>
                                 <option value="">선택</option>
-                                <option value="OFFICE_SUPPLIES">사무용품</option>
-                                <option value="ELECTRONICS">전자기기</option>
-                                <option value="FURNITURE">가구</option>
-                                <option value="TOOLS">공구</option>
-                                <option value="SAFETY_EQUIPMENT">안전장비</option>
                             </select>
                         </div>
                     </div>

--- a/src/main/resources/templates/equipment/equipmentList.html
+++ b/src/main/resources/templates/equipment/equipmentList.html
@@ -33,7 +33,7 @@
 
                 <!-- 페이징 영역 -->
                 <nav>
-                    <div id="pagination"></div>
+                    <div id="pagination" class="mt-4"></div>
                 </nav>
             </div>
 

--- a/src/main/resources/templates/equipment/equipmentList.html
+++ b/src/main/resources/templates/equipment/equipmentList.html
@@ -8,6 +8,7 @@
     <title>EquipRental - 장비 조회</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="/css/common/common.css">
+    <link rel="stylesheet" href="/css/equipment/equipmentList.css">
 </head>
 <body>
 <div class="wrapper">
@@ -15,13 +16,13 @@
         {{> common/userSidebar }}
         <main class="content">
             <div class="container-fluid mt-5">
-                <h2>장비 조회</h2>
                 <!-- 필터 영역 -->
-                <div id="equipment-filters" class="mt-3"></div>
-                <div id="sub-category-filters"></div>
+                <div class="filter-card p-3 mb-3 border rounded shadow-sm">
+                    <div id="category-filters" class="mt-3"></div>
+                    <div id="sub-category-filters" class="mt-3 mb-3"></div>
 
-                <!-- 검색창 -->
-                <div class="mb-3">
+                    <!-- 검색창 -->
+                    <label for="equipment-search"></label>
                     <input type="text" id="equipment-search" class="form-control" placeholder="모델 검색">
                 </div>
 


### PR DESCRIPTION
## 개요
- #15 

## 타입
- refactor: 코드/패키지 구조 변경 (기능 변경 없음)

## 작업 사항
- 카테고리 필터링: `categoryEnum` → `categoryId` 기반으로 변경
- 서브카테고리 필터링: 객체 비교 → `subCategoryId` 기반으로 변경
- 불필요한 enum 기반 접근 로직 제거
- QueryDSL 조건 및 DTO 매핑 개선
- 장비 도메인 서비스 로직 정리 및 최적화