### PR TITLE
feat: 건의/문의 게시판 구현

### DIFF
--- a/src/main/java/com/equip/equiprental/board/controller/BoardController.java
+++ b/src/main/java/com/equip/equiprental/board/controller/BoardController.java
@@ -1,0 +1,40 @@
+package com.equip.equiprental.board.controller;
+
+import com.equip.equiprental.auth.security.PrincipalDetails;
+import com.equip.equiprental.board.dto.BoardCreateRequest;
+import com.equip.equiprental.board.dto.BoardCreateResponse;
+import com.equip.equiprental.board.service.BoardService;
+import com.equip.equiprental.common.controller.ResponseController;
+import com.equip.equiprental.common.dto.ResponseDto;
+import com.equip.equiprental.common.interceptor.RequestTraceIdInterceptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/boards")
+public class BoardController implements ResponseController {
+    private final BoardService boardService;
+
+    @PostMapping("")
+    public ResponseEntity<ResponseDto<BoardCreateResponse>> createBoard(@RequestPart(value = "data") BoardCreateRequest boardCreateRequest,
+                                                                        @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                                                                        @AuthenticationPrincipal PrincipalDetails principal) {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("게시글 추가 요청 API] TraceId={}", traceId);
+
+        Long writerId = principal.getMember().getMemberId();
+
+        BoardCreateResponse result = boardService.createBoard(boardCreateRequest, files, writerId);
+
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "게시글 추가 요청 성공", result);
+    }
+}

--- a/src/main/java/com/equip/equiprental/board/controller/BoardController.java
+++ b/src/main/java/com/equip/equiprental/board/controller/BoardController.java
@@ -50,4 +50,14 @@ public class BoardController implements ResponseController {
 
         return makeResponseEntity(traceId, HttpStatus.OK, null, "게시글 조회 성공", result);
     }
+
+    @GetMapping("/notices")
+    public ResponseEntity<ResponseDto<List<BoardListResponse>>> getNotices() {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("공지글 최신 5개 조회 요청 API] TraceId={}", traceId);
+
+        List<BoardListResponse> result = boardService.getLatestNotices(5);
+
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "공지글 조회 성공", result);
+    }
 }

--- a/src/main/java/com/equip/equiprental/board/controller/BoardController.java
+++ b/src/main/java/com/equip/equiprental/board/controller/BoardController.java
@@ -3,9 +3,12 @@ package com.equip.equiprental.board.controller;
 import com.equip.equiprental.auth.security.PrincipalDetails;
 import com.equip.equiprental.board.dto.BoardCreateRequest;
 import com.equip.equiprental.board.dto.BoardCreateResponse;
+import com.equip.equiprental.board.dto.BoardListResponse;
 import com.equip.equiprental.board.service.BoardService;
 import com.equip.equiprental.common.controller.ResponseController;
+import com.equip.equiprental.common.dto.PageResponseDto;
 import com.equip.equiprental.common.dto.ResponseDto;
+import com.equip.equiprental.common.dto.SearchParamDto;
 import com.equip.equiprental.common.interceptor.RequestTraceIdInterceptor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,12 +32,22 @@ public class BoardController implements ResponseController {
                                                                         @RequestPart(value = "files", required = false) List<MultipartFile> files,
                                                                         @AuthenticationPrincipal PrincipalDetails principal) {
         String traceId = RequestTraceIdInterceptor.getTraceId();
-        log.info("게시글 추가 요청 API] TraceId={}", traceId);
+        log.info("게시글 등록 요청 API] TraceId={}", traceId);
 
         Long writerId = principal.getMember().getMemberId();
 
         BoardCreateResponse result = boardService.createBoard(boardCreateRequest, files, writerId);
 
-        return makeResponseEntity(traceId, HttpStatus.OK, null, "게시글 추가 요청 성공", result);
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "게시글 등록 요청 성공", result);
+    }
+
+    @GetMapping("")
+    public ResponseEntity<ResponseDto<PageResponseDto<BoardListResponse>>> getBoardList(@ModelAttribute SearchParamDto paramDto) {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("게시글 조회 요청 API] TraceId={}", traceId);
+
+        PageResponseDto<BoardListResponse> result = boardService.getBoardList(paramDto);
+
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "게시글 조회 성공", result);
     }
 }

--- a/src/main/java/com/equip/equiprental/board/controller/BoardController.java
+++ b/src/main/java/com/equip/equiprental/board/controller/BoardController.java
@@ -63,12 +63,23 @@ public class BoardController implements ResponseController {
     }
 
     @GetMapping("/{boardId}")
-    public ResponseEntity<ResponseDto<BoardDetailDto>> getBoardDetail(@PathVariable Long boardId) {
+    public ResponseEntity<ResponseDto<BoardDetailDto>> getBoardDetail(@PathVariable Long boardId,
+                                                                      @AuthenticationPrincipal PrincipalDetails principal) {
         String traceId = RequestTraceIdInterceptor.getTraceId();
         log.info("게시글 상세 조회 요청 API] TraceId={}", traceId);
 
-        BoardDetailDto result = boardService.getBoardDetail(boardId);
+        Long currentUserId = principal.getMember().getMemberId();
+        BoardDetailDto result = boardService.getBoardDetail(boardId, currentUserId);
 
         return makeResponseEntity(traceId, HttpStatus.OK, null, "게시글 상세 조회 성공", result);
+    }
+
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<Void>> softDeleteBoard(@PathVariable Long boardId) {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("게시글 논리 삭제 요청 API] TraceId={}", traceId);
+
+        boardService.softDeleteBoard(boardId);
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "게시글 논리 삭제 성공", null);
     }
 }

--- a/src/main/java/com/equip/equiprental/board/controller/BoardController.java
+++ b/src/main/java/com/equip/equiprental/board/controller/BoardController.java
@@ -3,6 +3,7 @@ package com.equip.equiprental.board.controller;
 import com.equip.equiprental.auth.security.PrincipalDetails;
 import com.equip.equiprental.board.dto.BoardCreateRequest;
 import com.equip.equiprental.board.dto.BoardCreateResponse;
+import com.equip.equiprental.board.dto.BoardDetailDto;
 import com.equip.equiprental.board.dto.BoardListResponse;
 import com.equip.equiprental.board.service.BoardService;
 import com.equip.equiprental.common.controller.ResponseController;
@@ -59,5 +60,15 @@ public class BoardController implements ResponseController {
         List<BoardListResponse> result = boardService.getLatestNotices(5);
 
         return makeResponseEntity(traceId, HttpStatus.OK, null, "공지글 조회 성공", result);
+    }
+
+    @GetMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<BoardDetailDto>> getBoardDetail(@PathVariable Long boardId) {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("게시글 상세 조회 요청 API] TraceId={}", traceId);
+
+        BoardDetailDto result = boardService.getBoardDetail(boardId);
+
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "게시글 상세 조회 성공", result);
     }
 }

--- a/src/main/java/com/equip/equiprental/board/controller/BoardController.java
+++ b/src/main/java/com/equip/equiprental/board/controller/BoardController.java
@@ -1,10 +1,7 @@
 package com.equip.equiprental.board.controller;
 
 import com.equip.equiprental.auth.security.PrincipalDetails;
-import com.equip.equiprental.board.dto.BoardCreateRequest;
-import com.equip.equiprental.board.dto.BoardCreateResponse;
-import com.equip.equiprental.board.dto.BoardDetailDto;
-import com.equip.equiprental.board.dto.BoardListResponse;
+import com.equip.equiprental.board.dto.*;
 import com.equip.equiprental.board.service.BoardService;
 import com.equip.equiprental.common.controller.ResponseController;
 import com.equip.equiprental.common.dto.PageResponseDto;
@@ -81,5 +78,17 @@ public class BoardController implements ResponseController {
 
         boardService.softDeleteBoard(boardId);
         return makeResponseEntity(traceId, HttpStatus.OK, null, "게시글 논리 삭제 성공", null);
+    }
+
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<BoardUpdateResponse>> updateBoard(@PathVariable Long boardId,
+                                                                        @RequestPart(value = "data") BoardUpdateRequest boardCreateRequest,
+                                                                        @RequestPart(value = "files", required = false) List<MultipartFile> files) {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("게시글 수정 요청 API] TraceId={}", traceId);
+
+        BoardUpdateResponse result = boardService.updateBoard(boardId, boardCreateRequest, files);
+
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "게시글 수정 성공", result);
     }
 }

--- a/src/main/java/com/equip/equiprental/board/controller/CommentController.java
+++ b/src/main/java/com/equip/equiprental/board/controller/CommentController.java
@@ -1,0 +1,39 @@
+package com.equip.equiprental.board.controller;
+
+import com.equip.equiprental.auth.security.PrincipalDetails;
+import com.equip.equiprental.board.dto.CommentCreateRequest;
+import com.equip.equiprental.board.dto.CommentCreateResponse;
+import com.equip.equiprental.board.service.CommentService;
+import com.equip.equiprental.common.controller.ResponseController;
+import com.equip.equiprental.common.dto.ResponseDto;
+import com.equip.equiprental.common.interceptor.RequestTraceIdInterceptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/comments")
+public class CommentController implements ResponseController {
+    private final CommentService commentService;
+
+    @PostMapping("")
+    public ResponseEntity<ResponseDto<CommentCreateResponse>> createComment(@RequestBody CommentCreateRequest dto,
+                                                                            @AuthenticationPrincipal PrincipalDetails principal) {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("댓글 등록 요청 API] TraceId={}", traceId);
+
+        Long writerId = principal.getMember().getMemberId();
+
+        CommentCreateResponse result = commentService.createComment(dto, writerId);
+
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "댓글 등록 성공", result);
+    }
+}

--- a/src/main/java/com/equip/equiprental/board/controller/CommentController.java
+++ b/src/main/java/com/equip/equiprental/board/controller/CommentController.java
@@ -3,19 +3,19 @@ package com.equip.equiprental.board.controller;
 import com.equip.equiprental.auth.security.PrincipalDetails;
 import com.equip.equiprental.board.dto.CommentCreateRequest;
 import com.equip.equiprental.board.dto.CommentCreateResponse;
+import com.equip.equiprental.board.dto.CommentListResponse;
 import com.equip.equiprental.board.service.CommentService;
 import com.equip.equiprental.common.controller.ResponseController;
+import com.equip.equiprental.common.dto.PageResponseDto;
 import com.equip.equiprental.common.dto.ResponseDto;
+import com.equip.equiprental.common.dto.SearchParamDto;
 import com.equip.equiprental.common.interceptor.RequestTraceIdInterceptor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -35,5 +35,15 @@ public class CommentController implements ResponseController {
         CommentCreateResponse result = commentService.createComment(dto, writerId);
 
         return makeResponseEntity(traceId, HttpStatus.OK, null, "댓글 등록 성공", result);
+    }
+
+    @GetMapping("")
+    public ResponseEntity<ResponseDto<PageResponseDto<CommentListResponse>>> getCommentList(@ModelAttribute SearchParamDto paramDto) {
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("댓글 조회 요청 API] TraceId={}", traceId);
+
+        PageResponseDto<CommentListResponse> result = commentService.getCommentList(paramDto);
+
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "댓글 조회 성공", result);
     }
 }

--- a/src/main/java/com/equip/equiprental/board/controller/CommentController.java
+++ b/src/main/java/com/equip/equiprental/board/controller/CommentController.java
@@ -38,11 +38,14 @@ public class CommentController implements ResponseController {
     }
 
     @GetMapping("")
-    public ResponseEntity<ResponseDto<PageResponseDto<CommentListResponse>>> getCommentList(@ModelAttribute SearchParamDto paramDto) {
+    public ResponseEntity<ResponseDto<PageResponseDto<CommentListResponse>>> getCommentList(@ModelAttribute SearchParamDto paramDto,
+                                                                                            @AuthenticationPrincipal PrincipalDetails principal) {
         String traceId = RequestTraceIdInterceptor.getTraceId();
         log.info("댓글 조회 요청 API] TraceId={}", traceId);
 
-        PageResponseDto<CommentListResponse> result = commentService.getCommentList(paramDto);
+        Long writerId = principal.getMember().getMemberId();
+
+        PageResponseDto<CommentListResponse> result = commentService.getCommentList(paramDto, writerId);
 
         return makeResponseEntity(traceId, HttpStatus.OK, null, "댓글 조회 성공", result);
     }

--- a/src/main/java/com/equip/equiprental/board/controller/CommentController.java
+++ b/src/main/java/com/equip/equiprental/board/controller/CommentController.java
@@ -49,4 +49,13 @@ public class CommentController implements ResponseController {
 
         return makeResponseEntity(traceId, HttpStatus.OK, null, "댓글 조회 성공", result);
     }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ResponseDto<Void>> softDeleteComment(@PathVariable Long commentId){
+        String traceId = RequestTraceIdInterceptor.getTraceId();
+        log.info("댓글 삭제 요청 API] TraceId={}", traceId);
+
+        commentService.softDeleteComment(commentId);
+        return makeResponseEntity(traceId, HttpStatus.OK, null, "댓글 삭제 성공", null);
+    }
 }

--- a/src/main/java/com/equip/equiprental/board/domain/Board.java
+++ b/src/main/java/com/equip/equiprental/board/domain/Board.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name="board_tbl")
 @Getter
@@ -33,4 +35,15 @@ public class Board extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private BoardStatus status;
+
+    @Column(name="is_deleted")
+    private Boolean isDeleted;
+
+    @Column(name="deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void softDelete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/equip/equiprental/board/domain/Board.java
+++ b/src/main/java/com/equip/equiprental/board/domain/Board.java
@@ -1,0 +1,36 @@
+package com.equip.equiprental.board.domain;
+
+import com.equip.equiprental.common.domain.BaseEntity;
+import com.equip.equiprental.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="board_tbl")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Board extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="board_id")
+    private Long boardId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="writer_id")
+    private Member writer;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="board_type")
+    private BoardType boardType;
+
+    private String title;
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private BoardStatus status;
+}

--- a/src/main/java/com/equip/equiprental/board/domain/Board.java
+++ b/src/main/java/com/equip/equiprental/board/domain/Board.java
@@ -1,5 +1,6 @@
 package com.equip.equiprental.board.domain;
 
+import com.equip.equiprental.board.dto.BoardUpdateRequest;
 import com.equip.equiprental.common.domain.BaseEntity;
 import com.equip.equiprental.member.domain.Member;
 import jakarta.persistence.*;
@@ -45,5 +46,11 @@ public class Board extends BaseEntity {
     public void softDelete() {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void updateBoard(BoardUpdateRequest dto) {
+        this.boardType = dto.getBoardType();
+        this.title = dto.getTitle();
+        this.content = dto.getContent();
     }
 }

--- a/src/main/java/com/equip/equiprental/board/domain/BoardStatus.java
+++ b/src/main/java/com/equip/equiprental/board/domain/BoardStatus.java
@@ -1,0 +1,6 @@
+package com.equip.equiprental.board.domain;
+
+public enum BoardStatus {
+    PENDING,
+    RESOLVE
+}

--- a/src/main/java/com/equip/equiprental/board/domain/BoardType.java
+++ b/src/main/java/com/equip/equiprental/board/domain/BoardType.java
@@ -1,0 +1,6 @@
+package com.equip.equiprental.board.domain;
+
+public enum BoardType {
+    SUGGESTION,
+    NOTICE
+}

--- a/src/main/java/com/equip/equiprental/board/domain/Comment.java
+++ b/src/main/java/com/equip/equiprental/board/domain/Comment.java
@@ -1,0 +1,4 @@
+package com.equip.equiprental.board.domain;
+
+public class Comment {
+}

--- a/src/main/java/com/equip/equiprental/board/domain/Comment.java
+++ b/src/main/java/com/equip/equiprental/board/domain/Comment.java
@@ -1,4 +1,40 @@
 package com.equip.equiprental.board.domain;
 
-public class Comment {
+import com.equip.equiprental.common.domain.BaseEntity;
+import com.equip.equiprental.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="comment_tbl")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Comment extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="commnet_id")
+    private Long CommentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="board_id")
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="writer_id")
+    private Member writer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="parent_id")
+    private Comment parent;
+
+    @Column(name="is_official")
+    private Boolean isOfficial;
+
+    @Column(name="content")
+    private String content;
 }

--- a/src/main/java/com/equip/equiprental/board/domain/Comment.java
+++ b/src/main/java/com/equip/equiprental/board/domain/Comment.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name="comment_tbl")
 @Getter
@@ -17,8 +20,8 @@ import lombok.NoArgsConstructor;
 public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="commnet_id")
-    private Long CommentId;
+    @Column(name="comment_id")
+    private Long commentId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="board_id")
@@ -37,4 +40,7 @@ public class Comment extends BaseEntity {
 
     @Column(name="content")
     private String content;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Comment> children = new ArrayList<>();
 }

--- a/src/main/java/com/equip/equiprental/board/domain/Comment.java
+++ b/src/main/java/com/equip/equiprental/board/domain/Comment.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,6 +42,17 @@ public class Comment extends BaseEntity {
     @Column(name="content")
     private String content;
 
+    @Column(name="is_deleted")
+    private Boolean isDeleted;
+
+    @Column(name="deleted_at")
+    private LocalDateTime deletedAt;
+
     @OneToMany(mappedBy = "parent")
     private List<Comment> children = new ArrayList<>();
+
+    public void softDelete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/equip/equiprental/board/domain/Comment.java
+++ b/src/main/java/com/equip/equiprental/board/domain/Comment.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -49,7 +48,7 @@ public class Comment extends BaseEntity {
     private LocalDateTime deletedAt;
 
     @OneToMany(mappedBy = "parent")
-    private List<Comment> children = new ArrayList<>();
+    private List<Comment> children;
 
     public void softDelete() {
         this.isDeleted = true;

--- a/src/main/java/com/equip/equiprental/board/dto/BoardCreateRequest.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardCreateRequest.java
@@ -1,0 +1,15 @@
+package com.equip.equiprental.board.dto;
+
+import com.equip.equiprental.board.domain.BoardType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BoardCreateRequest {
+    private BoardType boardType;
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/equip/equiprental/board/dto/BoardCreateResponse.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardCreateResponse.java
@@ -1,0 +1,33 @@
+package com.equip.equiprental.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BoardCreateResponse {
+    private Long boardId;
+    private String boardType;
+    private String title;
+    private String content;
+    private String status;
+    private LocalDateTime createdAt;
+    private List<BoardFile> files;
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class BoardFile {
+        private Long fileId;
+        private String originalName;
+        private String url;
+        private Integer fileOrder;
+        private String fileType;
+        private Long fileSize;
+    }
+}

--- a/src/main/java/com/equip/equiprental/board/dto/BoardDetailDto.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardDetailDto.java
@@ -1,6 +1,7 @@
 package com.equip.equiprental.board.dto;
 
 import com.equip.equiprental.board.domain.BoardType;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,4 +19,6 @@ public class BoardDetailDto {
     private String content;
     private LocalDateTime createdAt;
     private List<String> filePath;
+    @JsonProperty("isOwner")
+    private boolean owner;
 }

--- a/src/main/java/com/equip/equiprental/board/dto/BoardDetailDto.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardDetailDto.java
@@ -18,6 +18,7 @@ public class BoardDetailDto {
     private String title;
     private String content;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
     private List<BoardFileDto> files;
     @JsonProperty("isOwner")
     private boolean owner;

--- a/src/main/java/com/equip/equiprental/board/dto/BoardDetailDto.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardDetailDto.java
@@ -18,7 +18,7 @@ public class BoardDetailDto {
     private String title;
     private String content;
     private LocalDateTime createdAt;
-    private List<String> filePath;
+    private List<BoardFileDto> files;
     @JsonProperty("isOwner")
     private boolean owner;
 }

--- a/src/main/java/com/equip/equiprental/board/dto/BoardDetailDto.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardDetailDto.java
@@ -1,0 +1,21 @@
+package com.equip.equiprental.board.dto;
+
+import com.equip.equiprental.board.domain.BoardType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BoardDetailDto {
+    private Long boardId;
+    private BoardType boardType;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private List<String> filePath;
+}

--- a/src/main/java/com/equip/equiprental/board/dto/BoardFileDto.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardFileDto.java
@@ -1,0 +1,14 @@
+package com.equip.equiprental.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BoardFileDto {
+    private Long fileId;             // 파일 식별자
+    private String originalName; // 업로드 당시 이름
+    private String filePath;     // 저장된 경로
+}

--- a/src/main/java/com/equip/equiprental/board/dto/BoardListResponse.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardListResponse.java
@@ -1,0 +1,19 @@
+package com.equip.equiprental.board.dto;
+
+import com.equip.equiprental.board.domain.BoardType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BoardListResponse {
+    private Long boardId;
+    private BoardType boardType;
+    private String writerName;
+    private String title;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/equip/equiprental/board/dto/BoardUpdateRequest.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardUpdateRequest.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @AllArgsConstructor
 @Builder
@@ -12,4 +14,5 @@ public class BoardUpdateRequest {
     private BoardType boardType;
     private String title;
     private String content;
+    private List<Long> deletedFileIds;
 }

--- a/src/main/java/com/equip/equiprental/board/dto/BoardUpdateRequest.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.equip.equiprental.board.dto;
+
+import com.equip.equiprental.board.domain.BoardType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BoardUpdateRequest {
+    private BoardType boardType;
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/equip/equiprental/board/dto/BoardUpdateResponse.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardUpdateResponse.java
@@ -1,0 +1,19 @@
+package com.equip.equiprental.board.dto;
+
+import com.equip.equiprental.board.domain.BoardType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BoardUpdateResponse {
+    private Long boardId;
+    private BoardType boardType;
+    private String title;
+    private String content;
+    private List<String> filePaths;
+}

--- a/src/main/java/com/equip/equiprental/board/dto/BoardUpdateResponse.java
+++ b/src/main/java/com/equip/equiprental/board/dto/BoardUpdateResponse.java
@@ -15,5 +15,5 @@ public class BoardUpdateResponse {
     private BoardType boardType;
     private String title;
     private String content;
-    private List<String> filePaths;
+    private List<BoardFileDto> files;
 }

--- a/src/main/java/com/equip/equiprental/board/dto/CommentCreateRequest.java
+++ b/src/main/java/com/equip/equiprental/board/dto/CommentCreateRequest.java
@@ -9,5 +9,6 @@ import lombok.Getter;
 @Builder
 public class CommentCreateRequest {
     private Long boardId;
+    private Long parentCommentId;
     private String content;
 }

--- a/src/main/java/com/equip/equiprental/board/dto/CommentCreateRequest.java
+++ b/src/main/java/com/equip/equiprental/board/dto/CommentCreateRequest.java
@@ -1,0 +1,13 @@
+package com.equip.equiprental.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CommentCreateRequest {
+    private Long boardId;
+    private String content;
+}

--- a/src/main/java/com/equip/equiprental/board/dto/CommentCreateResponse.java
+++ b/src/main/java/com/equip/equiprental/board/dto/CommentCreateResponse.java
@@ -1,0 +1,16 @@
+package com.equip.equiprental.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CommentCreateResponse {
+    private Long commentId;
+    private Long boardId;
+    private Long writerId;
+    private boolean isOfficial;
+    private String content;
+}

--- a/src/main/java/com/equip/equiprental/board/dto/CommentListResponse.java
+++ b/src/main/java/com/equip/equiprental/board/dto/CommentListResponse.java
@@ -1,0 +1,44 @@
+package com.equip.equiprental.board.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CommentListResponse {
+    private Long commentId;
+    private Long writerId;
+    private String writerName;
+    private String content;
+    private Boolean isOfficial;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    @Builder.Default
+    private List<CommentListResponse> children = new ArrayList<>();
+
+    // QueryDSL constructor projection
+    @QueryProjection
+    public CommentListResponse(Long commentId,
+                               Long writerId,
+                               String writerName,
+                               String content,
+                               Boolean isOfficial,
+                               LocalDateTime createdAt,
+                               LocalDateTime updatedAt) {
+        this.commentId = commentId;
+        this.writerId = writerId;
+        this.writerName = writerName;
+        this.content = content;
+        this.isOfficial = isOfficial;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.children = new ArrayList<>();
+    }
+}

--- a/src/main/java/com/equip/equiprental/board/dto/CommentListResponse.java
+++ b/src/main/java/com/equip/equiprental/board/dto/CommentListResponse.java
@@ -18,6 +18,7 @@ public class CommentListResponse {
     private String writerName;
     private String content;
     private Boolean isOfficial;
+    private Boolean isOwner;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     @Builder.Default
@@ -30,6 +31,7 @@ public class CommentListResponse {
                                String writerName,
                                String content,
                                Boolean isOfficial,
+                               Boolean isOwner,
                                LocalDateTime createdAt,
                                LocalDateTime updatedAt) {
         this.commentId = commentId;
@@ -37,6 +39,7 @@ public class CommentListResponse {
         this.writerName = writerName;
         this.content = content;
         this.isOfficial = isOfficial;
+        this.isOwner = isOwner;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.children = new ArrayList<>();

--- a/src/main/java/com/equip/equiprental/board/repository/BoardRepository.java
+++ b/src/main/java/com/equip/equiprental/board/repository/BoardRepository.java
@@ -1,7 +1,8 @@
 package com.equip.equiprental.board.repository;
 
 import com.equip.equiprental.board.domain.Board;
+import com.equip.equiprental.board.repository.dsl.BoardQRepo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, Long>, BoardQRepo {
 }

--- a/src/main/java/com/equip/equiprental/board/repository/BoardRepository.java
+++ b/src/main/java/com/equip/equiprental/board/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package com.equip.equiprental.board.repository;
+
+import com.equip.equiprental.board.domain.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/com/equip/equiprental/board/repository/CommentRepository.java
+++ b/src/main/java/com/equip/equiprental/board/repository/CommentRepository.java
@@ -1,7 +1,8 @@
 package com.equip.equiprental.board.repository;
 
 import com.equip.equiprental.board.domain.Comment;
+import com.equip.equiprental.board.repository.dsl.CommentQRepo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentQRepo {
 }

--- a/src/main/java/com/equip/equiprental/board/repository/CommentRepository.java
+++ b/src/main/java/com/equip/equiprental/board/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.equip.equiprental.board.repository;
+
+import com.equip.equiprental.board.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepo.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepo.java
@@ -5,7 +5,9 @@ import com.equip.equiprental.board.dto.BoardListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface BoardQRepo {
     Page<BoardListResponse> findBoardList(Pageable pageable, BoardType type);
-
+    List<BoardListResponse>  findLatestNotices(int limit);
 }

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepo.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepo.java
@@ -2,12 +2,13 @@ package com.equip.equiprental.board.repository.dsl;
 
 import com.equip.equiprental.board.domain.BoardType;
 import com.equip.equiprental.board.dto.BoardListResponse;
+import com.equip.equiprental.common.dto.SearchParamDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface BoardQRepo {
-    Page<BoardListResponse> findBoardList(Pageable pageable, BoardType type);
+    Page<BoardListResponse> findBoardList(Pageable pageable, SearchParamDto paramDto);
     List<BoardListResponse>  findLatestNotices(int limit);
 }

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepo.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepo.java
@@ -1,10 +1,11 @@
 package com.equip.equiprental.board.repository.dsl;
 
+import com.equip.equiprental.board.domain.BoardType;
 import com.equip.equiprental.board.dto.BoardListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BoardQRepo {
-    Page<BoardListResponse> findBoardList(Pageable pageable);
+    Page<BoardListResponse> findBoardList(Pageable pageable, BoardType type);
 
 }

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepo.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepo.java
@@ -1,0 +1,10 @@
+package com.equip.equiprental.board.repository.dsl;
+
+import com.equip.equiprental.board.dto.BoardListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BoardQRepo {
+    Page<BoardListResponse> findBoardList(Pageable pageable);
+
+}

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
@@ -1,6 +1,5 @@
 package com.equip.equiprental.board.repository.dsl;
 
-import com.equip.equiprental.board.domain.Board;
 import com.equip.equiprental.board.domain.BoardType;
 import com.equip.equiprental.board.domain.QBoard;
 import com.equip.equiprental.board.dto.BoardListResponse;

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
@@ -26,7 +26,9 @@ public class BoardQRepoImpl implements BoardQRepo{
 
         BooleanBuilder builder = new BooleanBuilder();
 
-        builder.and(b.boardType.eq(type));
+        if (type != null) {
+            builder.and(b.boardType.eq(type));
+        }
 
         List<BoardListResponse> contents = queryFactory
                 .select(Projections.constructor(BoardListResponse.class,
@@ -50,5 +52,23 @@ public class BoardQRepoImpl implements BoardQRepo{
         total = total == null ? 0 : total;
 
         return new PageImpl<>(contents, pageable, total);
+    }
+
+    @Override
+    public List<BoardListResponse> findLatestNotices(int limit) {
+        QBoard b = QBoard.board;
+
+        return queryFactory
+                .select(Projections.constructor(BoardListResponse.class,
+                        b.boardId,
+                        b.boardType,
+                        b.writer.name,
+                        b.title,
+                        b.createdAt))
+                .from(b)
+                .where(b.boardType.eq(BoardType.NOTICE))
+                .orderBy(b.createdAt.desc())
+                .limit(limit)
+                .fetch();
     }
 }

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
@@ -1,0 +1,46 @@
+package com.equip.equiprental.board.repository.dsl;
+
+import com.equip.equiprental.board.domain.Board;
+import com.equip.equiprental.board.domain.QBoard;
+import com.equip.equiprental.board.dto.BoardListResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BoardQRepoImpl implements BoardQRepo{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<BoardListResponse> findBoardList(Pageable pageable) {
+        QBoard b = QBoard.board;
+
+        List<BoardListResponse> contents = queryFactory
+                .select(Projections.constructor(BoardListResponse.class,
+                        b.boardId,
+                        b.boardType,
+                        b.writer.name,
+                        b.title,
+                        b.createdAt))
+                .from(b)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(b.createdAt.desc())
+                .fetch();
+
+        Long total = queryFactory
+                .select(b.count())
+                .from(b)
+                .fetchOne();
+        total = total == null ? 0 : total;
+
+        return new PageImpl<>(contents, pageable, total);
+    }
+}

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
@@ -1,8 +1,10 @@
 package com.equip.equiprental.board.repository.dsl;
 
 import com.equip.equiprental.board.domain.Board;
+import com.equip.equiprental.board.domain.BoardType;
 import com.equip.equiprental.board.domain.QBoard;
 import com.equip.equiprental.board.dto.BoardListResponse;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +21,12 @@ public class BoardQRepoImpl implements BoardQRepo{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<BoardListResponse> findBoardList(Pageable pageable) {
+    public Page<BoardListResponse> findBoardList(Pageable pageable, BoardType type) {
         QBoard b = QBoard.board;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(b.boardType.eq(type));
 
         List<BoardListResponse> contents = queryFactory
                 .select(Projections.constructor(BoardListResponse.class,
@@ -30,6 +36,7 @@ public class BoardQRepoImpl implements BoardQRepo{
                         b.title,
                         b.createdAt))
                 .from(b)
+                .where(builder)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(b.createdAt.desc())
@@ -38,6 +45,7 @@ public class BoardQRepoImpl implements BoardQRepo{
         Long total = queryFactory
                 .select(b.count())
                 .from(b)
+                .where(builder)
                 .fetchOne();
         total = total == null ? 0 : total;
 

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
@@ -29,6 +29,8 @@ public class BoardQRepoImpl implements BoardQRepo{
             builder.and(b.boardType.eq(type));
         }
 
+        builder.and(b.isDeleted.eq(false));
+
         List<BoardListResponse> contents = queryFactory
                 .select(Projections.constructor(BoardListResponse.class,
                         b.boardId,
@@ -65,7 +67,8 @@ public class BoardQRepoImpl implements BoardQRepo{
                         b.title,
                         b.createdAt))
                 .from(b)
-                .where(b.boardType.eq(BoardType.NOTICE))
+                .where(b.boardType.eq(BoardType.NOTICE)
+                        .and(b.isDeleted.eq(false)))
                 .orderBy(b.createdAt.desc())
                 .limit(limit)
                 .fetch();

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/BoardQRepoImpl.java
@@ -3,6 +3,7 @@ package com.equip.equiprental.board.repository.dsl;
 import com.equip.equiprental.board.domain.BoardType;
 import com.equip.equiprental.board.domain.QBoard;
 import com.equip.equiprental.board.dto.BoardListResponse;
+import com.equip.equiprental.common.dto.SearchParamDto;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -20,13 +21,21 @@ public class BoardQRepoImpl implements BoardQRepo{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<BoardListResponse> findBoardList(Pageable pageable, BoardType type) {
+    public Page<BoardListResponse> findBoardList(Pageable pageable, SearchParamDto paramDto) {
         QBoard b = QBoard.board;
 
         BooleanBuilder builder = new BooleanBuilder();
 
-        if (type != null) {
-            builder.and(b.boardType.eq(type));
+        if (paramDto.getBoardType() != null) {
+            builder.and(b.boardType.eq(paramDto.getBoardType()));
+        }
+
+        if (paramDto.getKeyword() != null && !paramDto.getKeyword().isBlank()) {
+            if ("title".equalsIgnoreCase(paramDto.getSearchType())) {
+                builder.and(b.title.containsIgnoreCase(paramDto.getKeyword()));
+            } else if ("writer".equalsIgnoreCase(paramDto.getSearchType())) {
+                builder.and(b.writer.name.containsIgnoreCase(paramDto.getKeyword()));
+            }
         }
 
         builder.and(b.isDeleted.eq(false));

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/CommentQRepo.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/CommentQRepo.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CommentQRepo {
-    Page<CommentListResponse> findCommentList(Pageable pageable, Long boardId);
+    Page<CommentListResponse> findCommentList(Pageable pageable, Long boardId, Long writerId);
 }

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/CommentQRepo.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/CommentQRepo.java
@@ -1,0 +1,9 @@
+package com.equip.equiprental.board.repository.dsl;
+
+import com.equip.equiprental.board.dto.CommentListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentQRepo {
+    Page<CommentListResponse> findCommentList(Pageable pageable, Long boardId);
+}

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/CommentQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/CommentQRepoImpl.java
@@ -19,7 +19,6 @@ import java.util.List;
 public class CommentQRepoImpl implements CommentQRepo {
     private final JPAQueryFactory queryFactory;
 
-
     @Override
     public Page<CommentListResponse> findCommentList(Pageable pageable, Long boardId, Long writerId) {
         QComment c = QComment.comment;
@@ -31,6 +30,7 @@ public class CommentQRepoImpl implements CommentQRepo {
         }
 
         builder.and(c.parent.isNull());
+        builder.and(c.isDeleted.eq(false));
 
         List<CommentListResponse> contents = queryFactory
                 .select(new QCommentListResponse(
@@ -87,7 +87,8 @@ public class CommentQRepoImpl implements CommentQRepo {
 
         List<Comment> childComments = queryFactory
                 .selectFrom(c)
-                .where(c.parent.commentId.eq(parentId))
+                .where(c.parent.commentId.eq(parentId)
+                        .and(c.isDeleted.eq(false)))
                 .orderBy(c.createdAt.asc())
                 .fetch();
 

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/CommentQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/CommentQRepoImpl.java
@@ -21,7 +21,7 @@ public class CommentQRepoImpl implements CommentQRepo {
 
 
     @Override
-    public Page<CommentListResponse> findCommentList(Pageable pageable, Long boardId) {
+    public Page<CommentListResponse> findCommentList(Pageable pageable, Long boardId, Long writerId) {
         QComment c = QComment.comment;
 
         BooleanBuilder builder = new BooleanBuilder();
@@ -39,6 +39,7 @@ public class CommentQRepoImpl implements CommentQRepo {
                         c.writer.name,
                         c.content,
                         c.isOfficial,
+                        c.writer.memberId.eq(writerId),
                         c.createdAt,
                         c.updatedAt
                 ))
@@ -72,7 +73,7 @@ public class CommentQRepoImpl implements CommentQRepo {
 
             // 부모 댓글 DTO에 대댓글 매핑
             contents.forEach(parent -> {
-                parent.getChildren().addAll(fetchChildren(parent.getCommentId()));
+                parent.getChildren().addAll(fetchChildren(parent.getCommentId(), writerId));
             });
         }
 
@@ -81,7 +82,7 @@ public class CommentQRepoImpl implements CommentQRepo {
     }
 
     // 재귀적으로 children 채우기
-    private List<CommentListResponse> fetchChildren(Long parentId) {
+    private List<CommentListResponse> fetchChildren(Long parentId, Long writerId) {
         QComment c = QComment.comment;
 
         List<Comment> childComments = queryFactory
@@ -97,9 +98,10 @@ public class CommentQRepoImpl implements CommentQRepo {
                         child.getWriter().getName(),
                         child.getContent(),
                         child.getIsOfficial(),
+                        child.getWriter().getMemberId().equals(writerId),
                         child.getCreatedAt(),
                         child.getUpdatedAt(),
-                        fetchChildren(child.getCommentId()) // 재귀
+                        fetchChildren(child.getCommentId(), writerId) // 재귀
                 ))
                 .toList();
     }

--- a/src/main/java/com/equip/equiprental/board/repository/dsl/CommentQRepoImpl.java
+++ b/src/main/java/com/equip/equiprental/board/repository/dsl/CommentQRepoImpl.java
@@ -1,0 +1,97 @@
+package com.equip.equiprental.board.repository.dsl;
+
+import com.equip.equiprental.board.domain.Comment;
+import com.equip.equiprental.board.domain.QComment;
+import com.equip.equiprental.board.dto.CommentListResponse;
+import com.equip.equiprental.board.dto.QCommentListResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentQRepoImpl implements CommentQRepo {
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public Page<CommentListResponse> findCommentList(Pageable pageable, Long boardId) {
+        QComment c = QComment.comment;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(boardId != null) {
+            builder.and(c.board.boardId.eq(boardId));
+        }
+
+        builder.and(c.parent.isNull());
+
+        List<CommentListResponse> contents = queryFactory
+                .select(new QCommentListResponse(
+                        c.commentId,
+                        c.writer.memberId,
+                        c.writer.name,
+                        c.content,
+                        c.isOfficial,
+                        c.createdAt,
+                        c.updatedAt
+                ))
+                .from(c)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(c.createdAt.desc())
+                .fetch();
+
+        // 페이징 계산용 total count
+        Long total = queryFactory
+                .select(c.count())
+                .from(c)
+                .where(builder)
+                .fetchOne();
+        total = total == null ? 0 : total;
+
+        // 부모 댓글 ID 리스트 추출
+        List<Long> parentIds = contents.stream()
+                .map(CommentListResponse::getCommentId)
+                .toList();
+
+        if (!parentIds.isEmpty()) {
+            // 대댓글 조회
+            List<Comment> childComments = queryFactory
+                    .selectFrom(c)
+                    .where(c.parent.commentId.in(parentIds))
+                    .orderBy(c.createdAt.asc()) // 오래된 순
+                    .fetch();
+
+            // 부모 댓글 DTO에 대댓글 매핑
+            contents.forEach(parent -> {
+                List<CommentListResponse> children = childComments.stream()
+                        .filter(child -> child.getParent().getCommentId().equals(parent.getCommentId()))
+                        .map(child -> new CommentListResponse(
+                                child.getCommentId(),
+                                child.getWriter().getMemberId(),
+                                child.getWriter().getName(),
+                                child.getContent(),
+                                child.getIsOfficial(),
+                                child.getCreatedAt(),
+                                child.getUpdatedAt(),
+                                new ArrayList<>()
+                        ))
+                        .toList();
+                parent.getChildren().addAll(children);
+            });
+        }
+
+        // 최종 Page 반환
+        return new PageImpl<>(contents, pageable, total);
+    }
+}

--- a/src/main/java/com/equip/equiprental/board/service/BoardService.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardService.java
@@ -13,4 +13,5 @@ public interface BoardService {
     BoardCreateResponse createBoard(BoardCreateRequest dto, List<MultipartFile> files, Long writerId);
 
     PageResponseDto<BoardListResponse> getBoardList(SearchParamDto paramDto);
+    List<BoardListResponse> getLatestNotices(int i);
 }

--- a/src/main/java/com/equip/equiprental/board/service/BoardService.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardService.java
@@ -1,0 +1,11 @@
+package com.equip.equiprental.board.service;
+
+import com.equip.equiprental.board.dto.BoardCreateRequest;
+import com.equip.equiprental.board.dto.BoardCreateResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface BoardService {
+    BoardCreateResponse createBoard(BoardCreateRequest dto, List<MultipartFile> files, Long writerId);
+}

--- a/src/main/java/com/equip/equiprental/board/service/BoardService.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardService.java
@@ -2,6 +2,7 @@ package com.equip.equiprental.board.service;
 
 import com.equip.equiprental.board.dto.BoardCreateRequest;
 import com.equip.equiprental.board.dto.BoardCreateResponse;
+import com.equip.equiprental.board.dto.BoardDetailDto;
 import com.equip.equiprental.board.dto.BoardListResponse;
 import com.equip.equiprental.common.dto.PageResponseDto;
 import com.equip.equiprental.common.dto.SearchParamDto;
@@ -14,4 +15,6 @@ public interface BoardService {
 
     PageResponseDto<BoardListResponse> getBoardList(SearchParamDto paramDto);
     List<BoardListResponse> getLatestNotices(int i);
+
+    BoardDetailDto getBoardDetail(Long boardId);
 }

--- a/src/main/java/com/equip/equiprental/board/service/BoardService.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardService.java
@@ -1,9 +1,6 @@
 package com.equip.equiprental.board.service;
 
-import com.equip.equiprental.board.dto.BoardCreateRequest;
-import com.equip.equiprental.board.dto.BoardCreateResponse;
-import com.equip.equiprental.board.dto.BoardDetailDto;
-import com.equip.equiprental.board.dto.BoardListResponse;
+import com.equip.equiprental.board.dto.*;
 import com.equip.equiprental.common.dto.PageResponseDto;
 import com.equip.equiprental.common.dto.SearchParamDto;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,4 +16,6 @@ public interface BoardService {
     BoardDetailDto getBoardDetail(Long boardId, Long currentUserId);
 
     void softDeleteBoard(Long boardId);
+
+    BoardUpdateResponse updateBoard(Long boardId, BoardUpdateRequest boardCreateRequest, List<MultipartFile> files);
 }

--- a/src/main/java/com/equip/equiprental/board/service/BoardService.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardService.java
@@ -2,10 +2,15 @@ package com.equip.equiprental.board.service;
 
 import com.equip.equiprental.board.dto.BoardCreateRequest;
 import com.equip.equiprental.board.dto.BoardCreateResponse;
+import com.equip.equiprental.board.dto.BoardListResponse;
+import com.equip.equiprental.common.dto.PageResponseDto;
+import com.equip.equiprental.common.dto.SearchParamDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface BoardService {
     BoardCreateResponse createBoard(BoardCreateRequest dto, List<MultipartFile> files, Long writerId);
+
+    PageResponseDto<BoardListResponse> getBoardList(SearchParamDto paramDto);
 }

--- a/src/main/java/com/equip/equiprental/board/service/BoardService.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardService.java
@@ -16,5 +16,7 @@ public interface BoardService {
     PageResponseDto<BoardListResponse> getBoardList(SearchParamDto paramDto);
     List<BoardListResponse> getLatestNotices(int i);
 
-    BoardDetailDto getBoardDetail(Long boardId);
+    BoardDetailDto getBoardDetail(Long boardId, Long currentUserId);
+
+    void softDeleteBoard(Long boardId);
 }

--- a/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
@@ -106,7 +106,7 @@ public class BoardServiceImpl implements BoardService {
     public PageResponseDto<BoardListResponse> getBoardList(SearchParamDto paramDto) {
         Pageable pageable = paramDto.getPageable();
 
-        Page<BoardListResponse> dtosPage = boardRepository.findBoardList(pageable, paramDto.getBoardType());
+        Page<BoardListResponse> dtosPage = boardRepository.findBoardList(pageable, paramDto);
 
         return PageResponseDto.<BoardListResponse>builder()
                 .content(dtosPage.getContent())

--- a/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
@@ -5,6 +5,7 @@ import com.equip.equiprental.board.domain.BoardStatus;
 import com.equip.equiprental.board.domain.BoardType;
 import com.equip.equiprental.board.dto.BoardCreateRequest;
 import com.equip.equiprental.board.dto.BoardCreateResponse;
+import com.equip.equiprental.board.dto.BoardDetailDto;
 import com.equip.equiprental.board.dto.BoardListResponse;
 import com.equip.equiprental.board.repository.BoardRepository;
 import com.equip.equiprental.common.dto.PageResponseDto;
@@ -126,5 +127,27 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public List<BoardListResponse> getLatestNotices(int limit) {
         return boardRepository.findLatestNotices(limit);
+    }
+
+    @Override
+    @Transactional
+    public BoardDetailDto getBoardDetail(Long boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+        String relatedType = "board_" + board.getBoardType().name().toLowerCase();
+
+        List<String> paths = fileRepository.findAllByRelatedTypeAndRelatedId(relatedType, boardId)
+                .stream()
+                .map(FileMeta::getFilePath)
+                .toList();
+
+        return BoardDetailDto.builder()
+                .boardId(boardId)
+                .boardType(board.getBoardType())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .createdAt(board.getCreatedAt())
+                .filePath(paths)
+                .build();
     }
 }

--- a/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
@@ -36,7 +36,7 @@ public class BoardServiceImpl implements BoardService {
                 .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
 
         BoardType boardType = dto.getBoardType();
-        if (!writer.isAdmin() && boardType != BoardType.SUGGESTION) {
+        if (!writer.isAdminOrManager() && boardType != BoardType.SUGGESTION) {
             throw new CustomException(ErrorType.FORBIDDEN);
         }
 

--- a/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
@@ -107,7 +107,7 @@ public class BoardServiceImpl implements BoardService {
     public PageResponseDto<BoardListResponse> getBoardList(SearchParamDto paramDto) {
         Pageable pageable = paramDto.getPageable();
 
-        Page<BoardListResponse> dtosPage = boardRepository.findBoardList(pageable);
+        Page<BoardListResponse> dtosPage = boardRepository.findBoardList(pageable, paramDto.getBoardType());
 
         return PageResponseDto.<BoardListResponse>builder()
                 .content(dtosPage.getContent())

--- a/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
@@ -121,4 +121,10 @@ public class BoardServiceImpl implements BoardService {
                 .empty(dtosPage.isEmpty())
                 .build();
     }
+
+    @Override
+    @Transactional
+    public List<BoardListResponse> getLatestNotices(int limit) {
+        return boardRepository.findLatestNotices(limit);
+    }
 }

--- a/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
@@ -5,7 +5,10 @@ import com.equip.equiprental.board.domain.BoardStatus;
 import com.equip.equiprental.board.domain.BoardType;
 import com.equip.equiprental.board.dto.BoardCreateRequest;
 import com.equip.equiprental.board.dto.BoardCreateResponse;
+import com.equip.equiprental.board.dto.BoardListResponse;
 import com.equip.equiprental.board.repository.BoardRepository;
+import com.equip.equiprental.common.dto.PageResponseDto;
+import com.equip.equiprental.common.dto.SearchParamDto;
 import com.equip.equiprental.common.exception.CustomException;
 import com.equip.equiprental.common.exception.ErrorType;
 import com.equip.equiprental.filestorage.domain.FileMeta;
@@ -14,6 +17,8 @@ import com.equip.equiprental.filestorage.service.FileService;
 import com.equip.equiprental.member.domain.Member;
 import com.equip.equiprental.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -94,6 +99,26 @@ public class BoardServiceImpl implements BoardService {
                                 .fileSize(f.getFileSize())
                                 .build())
                         .toList())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public PageResponseDto<BoardListResponse> getBoardList(SearchParamDto paramDto) {
+        Pageable pageable = paramDto.getPageable();
+
+        Page<BoardListResponse> dtosPage = boardRepository.findBoardList(pageable);
+
+        return PageResponseDto.<BoardListResponse>builder()
+                .content(dtosPage.getContent())
+                .page(dtosPage.getNumber() + 1)
+                .size(dtosPage.getSize())
+                .totalElements(dtosPage.getTotalElements())
+                .totalPages(dtosPage.getTotalPages())
+                .numberOfElements(dtosPage.getNumberOfElements())
+                .first(dtosPage.isFirst())
+                .last(dtosPage.isLast())
+                .empty(dtosPage.isEmpty())
                 .build();
     }
 }

--- a/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
@@ -53,14 +53,15 @@ public class BoardServiceImpl implements BoardService {
 
         if(files != null && !files.isEmpty()) {
             int fileOrder = 0;
-            List<String> fileUrls = fileService.saveFiles(files, "board");
+            String typeKey = "board_" + boardType.name().toLowerCase();
+            List<String> fileUrls = fileService.saveFiles(files, typeKey);
 
             for (int i = 0; i < files.size(); i++) {
                 MultipartFile file = files.get(i);
                 String url = fileUrls.get(i); // fileService에서 생성한 접근 URL
 
                 FileMeta meta = FileMeta.builder()
-                        .relatedType("board_"+boardType.name().toLowerCase())
+                        .relatedType(typeKey)
                         .relatedId(board.getBoardId())
                         .originalName(file.getOriginalFilename())
                         .uniqueName(url.substring(url.lastIndexOf("/") + 1)) // URL 에서 uniqueName 추출

--- a/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
@@ -151,6 +151,7 @@ public class BoardServiceImpl implements BoardService {
                 .title(board.getTitle())
                 .content(board.getContent())
                 .createdAt(board.getCreatedAt())
+                .updatedAt(board.getUpdatedAt())
                 .files(files)
                 .owner(isOwner)
                 .build();

--- a/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
@@ -136,9 +136,13 @@ public class BoardServiceImpl implements BoardService {
         boolean isOwner = board.getWriter().getMemberId().equals(currentUserId);
 
         String relatedType = "board_" + board.getBoardType().name().toLowerCase();
-        List<String> paths = fileRepository.findAllByRelatedTypeAndRelatedId(relatedType, boardId)
+        List<BoardFileDto> files = fileRepository.findAllByRelatedTypeAndRelatedId(relatedType, boardId)
                 .stream()
-                .map(FileMeta::getFilePath)
+                .map(file -> BoardFileDto.builder()
+                        .fileId(file.getFileId())
+                        .originalName(file.getOriginalName())
+                        .filePath(file.getFilePath())
+                        .build())
                 .toList();
 
         return BoardDetailDto.builder()
@@ -147,7 +151,7 @@ public class BoardServiceImpl implements BoardService {
                 .title(board.getTitle())
                 .content(board.getContent())
                 .createdAt(board.getCreatedAt())
-                .filePath(paths)
+                .files(files)
                 .owner(isOwner)
                 .build();
     }

--- a/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/BoardServiceImpl.java
@@ -52,6 +52,7 @@ public class BoardServiceImpl implements BoardService {
                 .title(dto.getTitle())
                 .content(dto.getContent())
                 .status(BoardStatus.PENDING)
+                .isDeleted(false)
                 .build();
         boardRepository.save(board);
 

--- a/src/main/java/com/equip/equiprental/board/service/CommentService.java
+++ b/src/main/java/com/equip/equiprental/board/service/CommentService.java
@@ -9,5 +9,5 @@ import com.equip.equiprental.common.dto.SearchParamDto;
 public interface CommentService {
     CommentCreateResponse createComment(CommentCreateRequest dto, Long writerId);
 
-    PageResponseDto<CommentListResponse> getCommentList(SearchParamDto paramDto);
+    PageResponseDto<CommentListResponse> getCommentList(SearchParamDto paramDto, Long writerId);
 }

--- a/src/main/java/com/equip/equiprental/board/service/CommentService.java
+++ b/src/main/java/com/equip/equiprental/board/service/CommentService.java
@@ -1,0 +1,8 @@
+package com.equip.equiprental.board.service;
+
+import com.equip.equiprental.board.dto.CommentCreateRequest;
+import com.equip.equiprental.board.dto.CommentCreateResponse;
+
+public interface CommentService {
+    CommentCreateResponse createComment(CommentCreateRequest dto, Long writerId);
+}

--- a/src/main/java/com/equip/equiprental/board/service/CommentService.java
+++ b/src/main/java/com/equip/equiprental/board/service/CommentService.java
@@ -10,4 +10,6 @@ public interface CommentService {
     CommentCreateResponse createComment(CommentCreateRequest dto, Long writerId);
 
     PageResponseDto<CommentListResponse> getCommentList(SearchParamDto paramDto, Long writerId);
+
+    void softDeleteComment(Long commentId);
 }

--- a/src/main/java/com/equip/equiprental/board/service/CommentService.java
+++ b/src/main/java/com/equip/equiprental/board/service/CommentService.java
@@ -2,7 +2,12 @@ package com.equip.equiprental.board.service;
 
 import com.equip.equiprental.board.dto.CommentCreateRequest;
 import com.equip.equiprental.board.dto.CommentCreateResponse;
+import com.equip.equiprental.board.dto.CommentListResponse;
+import com.equip.equiprental.common.dto.PageResponseDto;
+import com.equip.equiprental.common.dto.SearchParamDto;
 
 public interface CommentService {
     CommentCreateResponse createComment(CommentCreateRequest dto, Long writerId);
+
+    PageResponseDto<CommentListResponse> getCommentList(SearchParamDto paramDto);
 }

--- a/src/main/java/com/equip/equiprental/board/service/CommentServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/CommentServiceImpl.java
@@ -35,11 +35,19 @@ public class CommentServiceImpl implements CommentService{
         Board board = boardRepository.findById(dto.getBoardId())
                 .orElseThrow(() -> new CustomException(ErrorType.BOARD_NOT_FOUND));
 
+        // parentCommentId가 있으면 찾아오기
+        Comment parent = null;
+        if (dto.getParentCommentId() != null) {
+            parent = commentRepository.findById(dto.getParentCommentId())
+                    .orElseThrow(() -> new CustomException(ErrorType.COMMENT_NOT_FOUND));
+        }
+
         boolean isOfficial = writer.isAdminOrManager();
 
         Comment comment = Comment.builder()
                 .board(board)
                 .writer(writer)
+                .parent(parent)
                 .isOfficial(isOfficial)
                 .content(dto.getContent())
                 .build();

--- a/src/main/java/com/equip/equiprental/board/service/CommentServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/CommentServiceImpl.java
@@ -1,0 +1,51 @@
+package com.equip.equiprental.board.service;
+
+import com.equip.equiprental.board.domain.Board;
+import com.equip.equiprental.board.domain.Comment;
+import com.equip.equiprental.board.dto.CommentCreateRequest;
+import com.equip.equiprental.board.dto.CommentCreateResponse;
+import com.equip.equiprental.board.repository.BoardRepository;
+import com.equip.equiprental.board.repository.CommentRepository;
+import com.equip.equiprental.common.exception.CustomException;
+import com.equip.equiprental.common.exception.ErrorType;
+import com.equip.equiprental.member.domain.Member;
+import com.equip.equiprental.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService{
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+
+    @Override
+    @Transactional
+    public CommentCreateResponse createComment(CommentCreateRequest dto, Long writerId) {
+        Member writer = memberRepository.findById(writerId)
+                .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+
+        Board board = boardRepository.findById(dto.getBoardId())
+                .orElseThrow(() -> new CustomException(ErrorType.BOARD_NOT_FOUND));
+
+        boolean isOfficial = writer.isAdminOrManager();
+
+        Comment comment = Comment.builder()
+                .board(board)
+                .writer(writer)
+                .isOfficial(isOfficial)
+                .content(dto.getContent())
+                .build();
+        commentRepository.save(comment);
+
+        return CommentCreateResponse.builder()
+                .commentId(comment.getCommentId())
+                .boardId(comment.getBoard().getBoardId())
+                .writerId(comment.getWriter().getMemberId())
+                .isOfficial(comment.getIsOfficial())
+                .content(comment.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/equip/equiprental/board/service/CommentServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/CommentServiceImpl.java
@@ -64,10 +64,10 @@ public class CommentServiceImpl implements CommentService{
 
     @Override
     @Transactional(readOnly = true)
-    public PageResponseDto<CommentListResponse> getCommentList(SearchParamDto paramDto) {
+    public PageResponseDto<CommentListResponse> getCommentList(SearchParamDto paramDto, Long writerId) {
         Pageable pageable = paramDto.getPageable();
 
-        Page<CommentListResponse> dtosPage = commentRepository.findCommentList(pageable, paramDto.getBoardId());
+        Page<CommentListResponse> dtosPage = commentRepository.findCommentList(pageable, paramDto.getBoardId(), writerId);
 
         return PageResponseDto.<CommentListResponse>builder()
                 .content(dtosPage.getContent())

--- a/src/main/java/com/equip/equiprental/board/service/CommentServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/CommentServiceImpl.java
@@ -4,13 +4,18 @@ import com.equip.equiprental.board.domain.Board;
 import com.equip.equiprental.board.domain.Comment;
 import com.equip.equiprental.board.dto.CommentCreateRequest;
 import com.equip.equiprental.board.dto.CommentCreateResponse;
+import com.equip.equiprental.board.dto.CommentListResponse;
 import com.equip.equiprental.board.repository.BoardRepository;
 import com.equip.equiprental.board.repository.CommentRepository;
+import com.equip.equiprental.common.dto.PageResponseDto;
+import com.equip.equiprental.common.dto.SearchParamDto;
 import com.equip.equiprental.common.exception.CustomException;
 import com.equip.equiprental.common.exception.ErrorType;
 import com.equip.equiprental.member.domain.Member;
 import com.equip.equiprental.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,6 +51,26 @@ public class CommentServiceImpl implements CommentService{
                 .writerId(comment.getWriter().getMemberId())
                 .isOfficial(comment.getIsOfficial())
                 .content(comment.getContent())
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponseDto<CommentListResponse> getCommentList(SearchParamDto paramDto) {
+        Pageable pageable = paramDto.getPageable();
+
+        Page<CommentListResponse> dtosPage = commentRepository.findCommentList(pageable, paramDto.getBoardId());
+
+        return PageResponseDto.<CommentListResponse>builder()
+                .content(dtosPage.getContent())
+                .page(dtosPage.getNumber() + 1)
+                .size(dtosPage.getSize())
+                .totalElements(dtosPage.getTotalElements())
+                .totalPages(dtosPage.getTotalPages())
+                .numberOfElements(dtosPage.getNumberOfElements())
+                .first(dtosPage.isFirst())
+                .last(dtosPage.isLast())
+                .empty(dtosPage.isEmpty())
                 .build();
     }
 }

--- a/src/main/java/com/equip/equiprental/board/service/CommentServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/board/service/CommentServiceImpl.java
@@ -50,6 +50,7 @@ public class CommentServiceImpl implements CommentService{
                 .parent(parent)
                 .isOfficial(isOfficial)
                 .content(dto.getContent())
+                .isDeleted(false)
                 .build();
         commentRepository.save(comment);
 
@@ -80,5 +81,18 @@ public class CommentServiceImpl implements CommentService{
                 .last(dtosPage.isLast())
                 .empty(dtosPage.isEmpty())
                 .build();
+    }
+
+    @Override
+    @Transactional
+    public void softDeleteComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorType.COMMENT_NOT_FOUND));
+
+        if (comment.getIsDeleted()) {
+            throw new CustomException(ErrorType.ALREADY_DELETED);
+        }
+
+        comment.softDelete();
     }
 }

--- a/src/main/java/com/equip/equiprental/common/config/FileProperties.java
+++ b/src/main/java/com/equip/equiprental/common/config/FileProperties.java
@@ -18,6 +18,6 @@ public class FileProperties {
     private Map<String, String> directories; // 서브 디렉토리 구분 (equipment, rental 등)
 
     public String getFullPath(String typeKey) {
-        return Paths.get(storagePath, directories.get(typeKey)).toString();
+        return Paths.get(storagePath, directories.getOrDefault(typeKey.split("_")[0], typeKey.split("_")[0]), typeKey.split("_")[1]).toString();
     }
 }

--- a/src/main/java/com/equip/equiprental/common/config/WebConfig.java
+++ b/src/main/java/com/equip/equiprental/common/config/WebConfig.java
@@ -12,9 +12,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
     private final RequestTraceIdInterceptor requestTraceIdInterceptor;
-
-    @Value("${file.storage-path}")
-    private String fileStoragePath;
+    private final FileProperties fileProperties;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -24,6 +22,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/files/**")
-                .addResourceLocations("file:" + fileStoragePath); // C:/equip_rental/files/
+                .addResourceLocations("file:" + fileProperties.getStoragePath() + "/"); // C:/equip_rental/files/~
     }
 }

--- a/src/main/java/com/equip/equiprental/common/dto/SearchParamDto.java
+++ b/src/main/java/com/equip/equiprental/common/dto/SearchParamDto.java
@@ -38,6 +38,8 @@ public class SearchParamDto {
     private Long departmentId;
 
     private BoardType boardType;
+    private String searchType;
+    private String keyword;
 
     private Long boardId;
 

--- a/src/main/java/com/equip/equiprental/common/dto/SearchParamDto.java
+++ b/src/main/java/com/equip/equiprental/common/dto/SearchParamDto.java
@@ -39,6 +39,8 @@ public class SearchParamDto {
 
     private BoardType boardType;
 
+    private Long boardId;
+
     public Pageable getPageable() {
         return PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
     }

--- a/src/main/java/com/equip/equiprental/common/dto/SearchParamDto.java
+++ b/src/main/java/com/equip/equiprental/common/dto/SearchParamDto.java
@@ -1,5 +1,6 @@
 package com.equip.equiprental.common.dto;
 
+import com.equip.equiprental.board.domain.BoardType;
 import com.equip.equiprental.common.exception.CustomException;
 import com.equip.equiprental.common.exception.ErrorType;
 import com.equip.equiprental.equipment.domain.EquipmentStatus;
@@ -35,6 +36,8 @@ public class SearchParamDto {
 
     private String memberName;
     private Long departmentId;
+
+    private BoardType boardType;
 
     public Pageable getPageable() {
         return PageRequest.of(page - 1, size, Sort.by("createdAt").descending());

--- a/src/main/java/com/equip/equiprental/common/exception/ErrorType.java
+++ b/src/main/java/com/equip/equiprental/common/exception/ErrorType.java
@@ -71,6 +71,7 @@ public enum ErrorType {
     // 게시판
     BOARD_NOT_FOUND("board_not_found","해당 게시글은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     ALREADY_DELETED("already_deleted", "이미 논리 삭제된 게시글입니다.", HttpStatus.CONFLICT),
+    COMMENT_NOT_FOUND("comment_not_found", "해당 댓글은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
     // 파일 관련
     FILE_NOT_FOUND("file_not_found", "파일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/equip/equiprental/common/exception/ErrorType.java
+++ b/src/main/java/com/equip/equiprental/common/exception/ErrorType.java
@@ -68,6 +68,9 @@ public enum ErrorType {
     ALREADY_RETURNED("already_returned", "이미 반납된 대여건은 연장할 수 없습니다.", HttpStatus.CONFLICT),
     CANNOT_EXTEND_OVERDUE("cannot_extend_overdue","이미 연체된 대여건은 연장할 수 없습니다.",HttpStatus.CONFLICT),
 
+    // 게시판
+    BOARD_NOT_FOUND("board_not_found","해당 게시글은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    ALREADY_DELETED("already_deleted", "이미 논리 삭제된 게시글입니다.", HttpStatus.CONFLICT),
 
     // 파일 관련
     FILE_NOT_FOUND("file_not_found", "파일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/equip/equiprental/common/route/AllViewController.java
+++ b/src/main/java/com/equip/equiprental/common/route/AllViewController.java
@@ -69,6 +69,13 @@ public class AllViewController {
         return "board/boardRegistration";
     }
 
+    @GetMapping("/board/{boardId}")
+    public String boardDetail(Model model, @AuthenticationPrincipal PrincipalDetails principal) {
+        model.addAttribute("isAdmin", principal.getMember().isAdminOrManager());
+
+        return "board/boardDetail";
+    }
+
     // 관리자 접근
     @GetMapping("/member")
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/equip/equiprental/common/route/AllViewController.java
+++ b/src/main/java/com/equip/equiprental/common/route/AllViewController.java
@@ -55,7 +55,7 @@ public class AllViewController {
         return "rental/rentalItemList";
     }
 
-    @GetMapping("/board/list")
+    @GetMapping("/board")
     public String boardList(Model model, @AuthenticationPrincipal PrincipalDetails principal) {
         model.addAttribute("isAdmin", principal.getMember().isAdminOrManager());
 

--- a/src/main/java/com/equip/equiprental/common/route/AllViewController.java
+++ b/src/main/java/com/equip/equiprental/common/route/AllViewController.java
@@ -76,6 +76,13 @@ public class AllViewController {
         return "board/boardDetail";
     }
 
+    @GetMapping("/board/{boardId}/update")
+    public String boardUpdate(Model model, @AuthenticationPrincipal PrincipalDetails principal) {
+        model.addAttribute("isAdmin", principal.getMember().isAdminOrManager());
+
+        return "board/boardUpdate";
+    }
+
     // 관리자 접근
     @GetMapping("/member")
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/equip/equiprental/common/route/AllViewController.java
+++ b/src/main/java/com/equip/equiprental/common/route/AllViewController.java
@@ -57,11 +57,16 @@ public class AllViewController {
 
     @GetMapping("/board/list")
     public String boardList(Model model, @AuthenticationPrincipal PrincipalDetails principal) {
-        boolean isAdmin = principal.getAuthorities().stream()
-                .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
-        model.addAttribute("isAdmin", isAdmin);
+        model.addAttribute("isAdmin", principal.getMember().isAdminOrManager());
 
         return "board/boardList";
+    }
+
+    @GetMapping("/board/registration")
+    public String boardRegistration(Model model, @AuthenticationPrincipal PrincipalDetails principal) {
+        model.addAttribute("isAdmin", principal.getMember().isAdminOrManager());
+
+        return "board/boardRegistration";
     }
 
     // 관리자 접근

--- a/src/main/java/com/equip/equiprental/common/route/AllViewController.java
+++ b/src/main/java/com/equip/equiprental/common/route/AllViewController.java
@@ -1,10 +1,13 @@
 package com.equip.equiprental.common.route;
 
+import com.equip.equiprental.auth.security.PrincipalDetails;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
@@ -50,6 +53,15 @@ public class AllViewController {
     @GetMapping("/rental/{rentalId}/item")
     public String userRentalItemList() {
         return "rental/rentalItemList";
+    }
+
+    @GetMapping("/board/list")
+    public String boardList(Model model, @AuthenticationPrincipal PrincipalDetails principal) {
+        boolean isAdmin = principal.getAuthorities().stream()
+                .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
+        model.addAttribute("isAdmin", isAdmin);
+
+        return "board/boardList";
     }
 
     // 관리자 접근

--- a/src/main/java/com/equip/equiprental/filestorage/repository/FileRepository.java
+++ b/src/main/java/com/equip/equiprental/filestorage/repository/FileRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface FileRepository extends JpaRepository<FileMeta, Long> {
@@ -15,4 +16,6 @@ public interface FileRepository extends JpaRepository<FileMeta, Long> {
     List<String> findUrlsByEquipmentId(@Param("equipmentId") Long equipmentId);
 
     List<FileMeta> findByRelatedTypeAndRelatedId(String equipment, Long equipmentId);
+
+    List<FileMeta> findAllByRelatedTypeAndRelatedId(String relatedType, Long boardId);
 }

--- a/src/main/java/com/equip/equiprental/filestorage/service/FileService.java
+++ b/src/main/java/com/equip/equiprental/filestorage/service/FileService.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface FileService {
     List<String> saveFiles(List<MultipartFile> files, String typeKey);
+    void deleteFile(String filePath, String typeKey);
 }

--- a/src/main/java/com/equip/equiprental/filestorage/service/FileServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/filestorage/service/FileServiceImpl.java
@@ -33,7 +33,7 @@ public class FileServiceImpl implements FileService {
     private List<String> generateAccessUrl(List<StoredFile> savedFilenames, String typeKey) {
         String baseUrl = fileProperties.getAccessUrlBase().replaceAll("/+$", ""); // 끝의 슬래시 모두 제거
         return savedFilenames.stream()
-                .map(file -> String.format("%s/%s/%s", baseUrl, typeKey, file.getLocalFileName()))
+                .map(file -> String.format("%s/%s/%s", baseUrl, typeKey.replace("_","/"), file.getLocalFileName()))
                 .toList();
     }
 }

--- a/src/main/java/com/equip/equiprental/filestorage/service/FileServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/filestorage/service/FileServiceImpl.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 @Service
@@ -23,6 +27,31 @@ public class FileServiceImpl implements FileService {
             return generateAccessUrl(savedFilenames, typeKey);
         } catch (IOException e) {
             throw new RuntimeException("파일 저장 중 오류 발생", e);
+        }
+    }
+
+    // 삭제 기능
+    @Override
+    public void deleteFile(String filePath, String typeKey) {
+        if (filePath == null || filePath.isBlank()) return;
+
+        // URL에서 파일명만 추출
+        String fileName = Paths.get(URI.create(filePath).getPath()).getFileName().toString();
+
+        // FileProperties를 사용해 실제 저장 경로 계산
+        String fullDir = fileProperties.getFullPath(typeKey);
+        Path path = Paths.get(fullDir, fileName);
+
+        // 실제 파일 삭제
+        try {
+            if (Files.exists(path)) {
+                Files.delete(path);
+                System.out.println("삭제 성공: " + path);
+            } else {
+                System.out.println("삭제할 파일 없음: " + path);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("파일 삭제 실패: " + path, e);
         }
     }
 

--- a/src/main/java/com/equip/equiprental/member/domain/Member.java
+++ b/src/main/java/com/equip/equiprental/member/domain/Member.java
@@ -41,4 +41,8 @@ public class Member extends BaseEntity {
     public void updateRole(MemberRole newRole) {
         this.role = newRole;
     }
+
+    public boolean isAdmin() {
+        return this.role == MemberRole.ADMIN;
+    }
 }

--- a/src/main/java/com/equip/equiprental/member/domain/Member.java
+++ b/src/main/java/com/equip/equiprental/member/domain/Member.java
@@ -42,7 +42,7 @@ public class Member extends BaseEntity {
         this.role = newRole;
     }
 
-    public boolean isAdmin() {
-        return this.role == MemberRole.ADMIN;
+    public boolean isAdminOrManager() {
+        return this.role == MemberRole.ADMIN || this.role == MemberRole.MANAGER;
     }
 }

--- a/src/main/java/com/equip/equiprental/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/member/service/MemberServiceImpl.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,4 +10,4 @@ file:
   storage-path: C:/equip_rental/files/
   directories:
     equipment: equipment
-    rental: rental
+    board: board

--- a/src/main/resources/static/css/board/boardList.css
+++ b/src/main/resources/static/css/board/boardList.css
@@ -1,0 +1,3 @@
+.list-header {
+    border-bottom: 2px solid darkslateblue; /* 진한 빨간색 등 가능 */
+}

--- a/src/main/resources/static/js/board/boardDetail.js
+++ b/src/main/resources/static/js/board/boardDetail.js
@@ -149,11 +149,17 @@ function renderCommentList(comments, container = $("#comment-list"), level = 0) 
         html += `
           <li class="list-group-item mt-2" data-comment-id="${c.commentId}">
             <strong>${c.writerName}</strong> 
-            <small class="text-muted">${new Date(c.createdAt).toLocaleString()}</small>
+            <small class="text-muted">
+                ${new Date(c.createdAt).toLocaleString()}
+                ${c.isOwner ? `
+                    <button class="btn btn-sm btn-outline-primary edit-comment">수정</button>
+                    <button class="btn btn-sm btn-outline-danger delete-comment">삭제</button>
+                ` : ''}
+            </small>
             <p>${c.content}</p>
             
             <button class="btn btn-sm btn-link reply-toggle">답글 달기</button>
-
+            
             <div class="reply-section mt-2" style="display:none;">
                 <textarea class="form-control mb-1 reply-content" rows="2" placeholder="답글을 입력하세요."></textarea>
                 <button class="btn btn-sm btn-secondary submit-reply">등록</button>

--- a/src/main/resources/static/js/board/boardDetail.js
+++ b/src/main/resources/static/js/board/boardDetail.js
@@ -29,7 +29,7 @@ function renderBoardDetail(board) {
     if (board.files && board.files.length > 0) {
         const images = board.files
             .map(f => f.filePath)
-            .filter(path => /\.(jpg|jpeg|png|gif)$/i.test(path));
+            .filter(path => /\.(jpg|jpeg|png|gif|webp)$/i.test(path));
 
         if (images.length > 0) {
             imageHtml = `

--- a/src/main/resources/static/js/board/boardDetail.js
+++ b/src/main/resources/static/js/board/boardDetail.js
@@ -8,6 +8,7 @@ $(document).ready(function() {
     fetchComments(boardId);
 });
 
+// 게시글 상세 조회 호출
 function fetchBoardDetail(boardId) {
     $.ajax({
         url: `/api/v1/boards/${boardId}`,
@@ -19,6 +20,7 @@ function fetchBoardDetail(boardId) {
     });
 }
 
+// 게시글 상세 조회 렌더링
 function renderBoardDetail(board) {
     const container = $("#board-detail");
 
@@ -75,6 +77,7 @@ function renderBoardDetail(board) {
     container.html(html);
 }
 
+// 게시글 수정
 $(document).on("click", "#update-board-btn", function() {
     const boardId = $(this).data("board-id");
 
@@ -83,6 +86,7 @@ $(document).on("click", "#update-board-btn", function() {
     }
 });
 
+// 게시글 삭제 버튼
 $(document).on("click", "#delete-board-btn", function() {
     const boardId = $(this).data("board-id");
 
@@ -91,6 +95,7 @@ $(document).on("click", "#delete-board-btn", function() {
     }
 });
 
+// 게시글 삭제 api 호출
 function deleteBoard(boardId) {
     $.ajax({
         url: `/api/v1/boards/${boardId}`,
@@ -101,6 +106,7 @@ function deleteBoard(boardId) {
     }).fail(handleServerError);
 }
 
+// 댓글 작성 api 호출
 $(document).on("click", "#submit-comment", function() {
     const boardId = $("#board-detail-content").data("board-id");
     const content = $("#comment-content").val().trim();
@@ -124,6 +130,7 @@ $(document).on("click", "#submit-comment", function() {
     }).fail(handleServerError);
 });
 
+// 댓글 조회 api 호출
 function fetchComments(boardId) {
     $.ajax({
         url: `/api/v1/comments?boardId=${boardId}&page=1&size=10`, // 페이지네이션 필요시
@@ -152,7 +159,6 @@ function renderCommentList(comments, container = $("#comment-list"), level = 0) 
             <small class="text-muted">
                 ${new Date(c.createdAt).toLocaleString()}
                 ${c.isOwner ? `
-                    <button class="btn btn-sm btn-outline-primary edit-comment">수정</button>
                     <button class="btn btn-sm btn-outline-danger delete-comment">삭제</button>
                 ` : ''}
             </small>
@@ -212,4 +218,21 @@ $(document).on("click", ".submit-reply", function() {
         showSnackbar(response.message);
         fetchComments(boardId); // 등록 후 전체 댓글/답글 다시 조회
     }).fail(handleServerError);
+});
+
+// 댓글 삭제 버튼 클릭
+$(document).on("click", ".delete-comment", function() {
+    const commentLi = $(this).closest("li[data-comment-id]");
+    const commentId = commentLi.data("comment-id");
+    const boardId = $("#board-detail-content").data("board-id");
+
+    if (confirm("정말 댓글을 삭제하시겠습니까?")) {
+        $.ajax({
+            url: `/api/v1/comments/${commentId}`, // 논리 삭제 API 엔드포인트
+            type: "DELETE"
+        }).done(function(response) {
+            showSnackbar(response.message || "댓글이 삭제되었습니다.");
+            fetchComments(boardId); // 삭제 후 전체 댓글 다시 조회
+        }).fail(handleServerError);
+    }
 });

--- a/src/main/resources/static/js/board/boardDetail.js
+++ b/src/main/resources/static/js/board/boardDetail.js
@@ -24,7 +24,6 @@ function renderBoardDetail(board) {
     const typeBadge = board.boardType === 'NOTICE' ? 'danger' : 'primary';
     const typeText = board.boardType === 'NOTICE' ? '공지사항' : '건의/문의';
 
-    let fileHtml = '';
     let imageHtml = '';
 
     if (board.filePath && board.filePath.length > 0) {
@@ -42,6 +41,11 @@ function renderBoardDetail(board) {
         }
     }
 
+    // 삭제 버튼 조건부 생성
+    const deleteBtnHtml = board.isOwner
+        ? `<button id="delete-board-btn" class="btn btn-danger ms-2" data-board-id="${board.boardId}">삭제하기</button>`
+        : '';
+
     const html = `
         <div class="card mb-3">
             <div class="card-header">
@@ -57,7 +61,26 @@ function renderBoardDetail(board) {
             </div>
         </div>
         <a href="/board" class="btn btn-secondary">목록으로</a>
+        ${deleteBtnHtml}
     `;
 
     container.html(html);
+}
+
+$(document).on("click", "#delete-board-btn", function() {
+    const boardId = $(this).data("board-id");
+
+    if (confirm("정말 삭제하시겠습니까?")) {
+        deleteBoard(boardId);
+    }
+});
+
+function deleteBoard(boardId) {
+    $.ajax({
+        url: `/api/v1/boards/${boardId}`,
+        type: "DELETE"
+    }).done(() => {
+        alert("게시글이 삭제되었습니다.");
+        window.location.href = "/board";
+    }).fail(handleServerError);
 }

--- a/src/main/resources/static/js/board/boardDetail.js
+++ b/src/main/resources/static/js/board/boardDetail.js
@@ -26,18 +26,20 @@ function renderBoardDetail(board) {
 
     let imageHtml = '';
 
-    if (board.filePath && board.filePath.length > 0) {
-        const images = board.filePath.filter(f => /\.(jpg|jpeg|png|gif)$/i.test(f));
+    if (board.files && board.files.length > 0) {
+        const images = board.files
+            .map(f => f.filePath)
+            .filter(path => /\.(jpg|jpeg|png|gif)$/i.test(path));
 
         if (images.length > 0) {
             imageHtml = `
-                <div class="mt-3">
-                    <strong>이미지 첨부:</strong>
-                    <div class="d-flex flex-wrap">
-                        ${images.map(f => `<img src="${f}" class="img-thumbnail me-2 mb-2" style="max-width:150px;">`).join('')}
-                    </div>
+            <div class="mt-3">
+                <strong>이미지 첨부:</strong>
+                <div class="d-flex flex-wrap">
+                    ${images.map(p => `<img src="${p}" class="img-thumbnail me-2 mb-2" style="max-width:150px;">`).join('')}
                 </div>
-            `;
+            </div>
+        `;
         }
     }
 

--- a/src/main/resources/static/js/board/boardDetail.js
+++ b/src/main/resources/static/js/board/boardDetail.js
@@ -41,9 +41,13 @@ function renderBoardDetail(board) {
         }
     }
 
+    const updateBtnHtml = board.isOwner
+        ? `<button id="update-board-btn" class="btn btn-primary ms-2" data-board-id="${board.boardId}">글 수정</button>`
+        : '';
+    
     // 삭제 버튼 조건부 생성
     const deleteBtnHtml = board.isOwner
-        ? `<button id="delete-board-btn" class="btn btn-danger ms-2" data-board-id="${board.boardId}">삭제하기</button>`
+        ? `<button id="delete-board-btn" class="btn btn-danger ms-2" data-board-id="${board.boardId}">글 삭제</button>`
         : '';
 
     const html = `
@@ -60,12 +64,21 @@ function renderBoardDetail(board) {
                 작성일: ${new Date(board.createdAt).toLocaleString()}
             </div>
         </div>
-        <a href="/board" class="btn btn-secondary">목록으로</a>
+        <a href="/board" class="btn btn-secondary">목록 이동</a>
+        ${updateBtnHtml}
         ${deleteBtnHtml}
     `;
 
     container.html(html);
 }
+
+$(document).on("click", "#update-board-btn", function() {
+    const boardId = $(this).data("board-id");
+
+    if (confirm("글 수정 화면 이동 하시겠습니까?")) {
+        window.location.href = `/board/${boardId}/update`;
+    }
+});
 
 $(document).on("click", "#delete-board-btn", function() {
     const boardId = $(this).data("board-id");

--- a/src/main/resources/static/js/board/boardDetail.js
+++ b/src/main/resources/static/js/board/boardDetail.js
@@ -1,0 +1,63 @@
+$(document).ready(function() {
+    // URL에서 boardId 추출
+    const pathParts = window.location.pathname.split("/"); // e.g., /board/1
+    const boardId = pathParts[pathParts.length - 1];
+
+    // 게시글 상세 조회
+    fetchBoardDetail(boardId);
+});
+
+function fetchBoardDetail(boardId) {
+    $.ajax({
+        url: `/api/v1/boards/${boardId}`,
+        type: "GET"
+    }).done(function(response) {
+        renderBoardDetail(response.data);
+    }).fail(function(xhr) {
+        handleServerError(xhr);
+    });
+}
+
+function renderBoardDetail(board) {
+    const container = $("#board-detail");
+
+    const typeBadge = board.boardType === 'NOTICE' ? 'danger' : 'primary';
+    const typeText = board.boardType === 'NOTICE' ? '공지사항' : '건의/문의';
+
+    let fileHtml = '';
+    let imageHtml = '';
+
+    if (board.filePath && board.filePath.length > 0) {
+        const images = board.filePath.filter(f => /\.(jpg|jpeg|png|gif)$/i.test(f));
+
+        if (images.length > 0) {
+            imageHtml = `
+                <div class="mt-3">
+                    <strong>이미지 첨부:</strong>
+                    <div class="d-flex flex-wrap">
+                        ${images.map(f => `<img src="${f}" class="img-thumbnail me-2 mb-2" style="max-width:150px;">`).join('')}
+                    </div>
+                </div>
+            `;
+        }
+    }
+
+    const html = `
+        <div class="card mb-3">
+            <div class="card-header">
+                <span class="badge bg-${typeBadge} me-2">${typeText}</span>
+                ${board.title}
+            </div>
+            <div class="card-body">
+                <p>${board.content}</p>
+                ${imageHtml}
+            </div>
+            <div class="card-footer text-muted">
+                작성일: ${new Date(board.createdAt).toLocaleString()}
+            </div>
+        </div>
+        <a href="/board" class="btn btn-secondary">목록으로</a>
+    `;
+
+    container.html(html);
+}

--- a/src/main/resources/static/js/board/boardDetail.js
+++ b/src/main/resources/static/js/board/boardDetail.js
@@ -67,6 +67,7 @@ function renderBoardDetail(board) {
             </div>
             <div class="card-footer text-muted">
                 작성일: ${new Date(board.createdAt).toLocaleString()}
+                 ${board.updatedAt ? ' <small class="text-secondary ms-1">수정됨</small>' : ''}
             </div>
         </div>
         <a href="/board" class="btn btn-secondary">목록 이동</a>

--- a/src/main/resources/static/js/board/boardList.js
+++ b/src/main/resources/static/js/board/boardList.js
@@ -2,6 +2,20 @@ let filters = {}; // 기본 필터
 let onlyNotices = false; // 공지사항 전용 모드 여부
 
 $(document).ready(function () {
+    $("#search-keyword").on("input", function() {
+        const searchType = $("#search-type").val();
+        const keyword = $(this).val();
+
+        filters.searchType = searchType;
+        filters.keyword = keyword;
+
+        if (onlyNotices) {
+            fetchNoticeBoards(filters);  // 공지 모드일 땐 여기로
+        } else {
+            fetchBoardList(filters);     // 일반 모드일 땐 여기로
+        }
+    });
+
     loadBoardPage(); // 초기 로드
 
     // 버튼 이벤트

--- a/src/main/resources/static/js/board/boardList.js
+++ b/src/main/resources/static/js/board/boardList.js
@@ -1,16 +1,55 @@
-let filters = {}; // 기본적으로 빈 객체
+let filters = {}; // 기본 필터
+let onlyNotices = false; // 공지사항 전용 모드 여부
 
 $(document).ready(function () {
-    fetchBoardList(); // 초기 로드
+    loadBoardPage(); // 초기 로드
+
+    // 버튼 이벤트
+    $("#toggleNoticeBtn").click(function () {
+        onlyNotices = !onlyNotices; // 모드 토글
+        if (onlyNotices) {
+            $(this).text("전체 글 보기");
+        } else {
+            $(this).text("공지사항만 보기");
+        }
+        loadBoardPage();
+    });
 });
 
-function fetchBoardList() {
+// 초기 로드
+function loadBoardPage() {
+    if (onlyNotices) {
+        // 공지사항만 보기 모드
+        fetchNoticeBoards();
+    } else {
+        // 1) 공지 5개
+        fetchNotices();
+        // 2) 일반글 10개
+        fetchBoardList(filters);
+    }
+}
+
+// 공지 5개 조회
+function fetchNotices() {
+    $.ajax({
+        url: "/api/v1/boards/notices",
+        type: "GET"
+    }).done(function (response) {
+        renderNoticeList(response.data);
+    }).fail(handleServerError);
+}
+
+// 일반글 10개 조회
+function fetchBoardList(params = {}) {
     $.ajax({
         url: "/api/v1/boards",
         type: "GET",
-        data: filters,
-    }).done(function(response) {
-        renderBoardList(response.data.content); // 리스트
+        data: {
+            ...params,
+            boardType: "SUGGESTION"
+        }
+    }).done(function (response) {
+        renderBoardList(response.data.content);
         renderPagination("pagination", {
             page: response.data.page,
             totalPages: response.data.totalPages,
@@ -22,12 +61,48 @@ function fetchBoardList() {
     }).fail(handleServerError);
 }
 
-// 게시글 리스트 렌더링
-function renderBoardList(list) {
-    const noticeContainer = $("#notice-list");
-    const boardContainer = $("#board-list");
+// 공지사항만 보기 (10개 페이징)
+function fetchNoticeBoards(params = {}) {
+    $.ajax({
+        url: "/api/v1/boards",
+        type: "GET",
+        data: {
+            ...filters,
+            boardType: "NOTICE"
+        }
+    }).done(function (response) {
+        $("#notice-list").empty(); // 상단 공지 영역 제거
+        renderBoardList(response.data.content);
+        renderPagination("pagination", {
+            page: response.data.page,
+            totalPages: response.data.totalPages,
+            first: response.data.first,
+            last: response.data.last
+        }, (newPage) => {
+            fetchNoticeBoards({ page: newPage });
+        });
+    }).fail(handleServerError);
+}
 
+// 공지글 전용 렌더링
+function renderNoticeList(list) {
+    const noticeContainer = $("#notice-list");
     noticeContainer.empty();
+
+    if (!list || list.length === 0) {
+        noticeContainer.append(`<div class="text-center py-2">공지글이 없습니다.</div>`);
+        return;
+    }
+
+    list.forEach(board => {
+        const row = renderRow(board, true);
+        noticeContainer.append(row);
+    });
+}
+
+// 공지 + 일반글 렌더링 공통 함수
+function renderBoardList(list) {
+    const boardContainer = $("#board-list");
     boardContainer.empty();
 
     if (!list || list.length === 0) {
@@ -36,29 +111,25 @@ function renderBoardList(list) {
     }
 
     list.forEach(board => {
-        const isNotice = board.boardType === "NOTICE";
-        const type = isNotice ? "공지사항" : "건의/문의";
-
-        const row = $(`
-            <div class="d-flex py-2 fw-bold">
-                <div class="col-1 text-center">${board.boardId}</div>
-                <div class="col-1 text-center me-3" style="${isNotice ? 'border: 1px solid rgba(255,0,0,0.5); border-radius: 4px; color: red;' : ''}">
-                    ${type}
-                </div>
-                <div class="col-5" style="${isNotice ? 'color: red;' : ''}">
-                    <a href="/board/${board.boardId}" style="${isNotice ? 'color: red;' : ''}">${board.title}</a>
-                </div>
-                <div class="col-2 text-center">${board.writerName}</div>
-                <div class="col-3 text-center">
-                    ${new Date(board.createdAt).toLocaleDateString()}
-                </div>
-            </div>
-        `);
-
-        if (isNotice) {
-            noticeContainer.append(row);
-        } else {
-            boardContainer.append(row);
-        }
+        const row = renderRow(board, board.boardType === "NOTICE");
+        boardContainer.append(row);
     });
+}
+
+// 행 렌더링
+function renderRow(board, isNotice) {
+    const type = isNotice ? "공지사항" : "건의/문의";
+    return $(`
+        <div class="d-flex py-2 fw-bold">
+            <div class="col-1 text-center">${board.boardId}</div>
+            <div class="col-1 text-center me-3" style="${isNotice ? 'border: 1px solid rgba(255,0,0,0.5); border-radius: 4px; color: red;' : ''}">
+                ${type}
+            </div>
+            <div class="col-5" style="${isNotice ? 'color: red;' : ''}">
+                <a href="/board/${board.boardId}" style="${isNotice ? 'color: red;' : ''}">${board.title}</a>
+            </div>
+            <div class="col-2 text-center">${board.writerName}</div>
+            <div class="col-3 text-center">${new Date(board.createdAt).toLocaleDateString()}</div>
+        </div>
+    `);
 }

--- a/src/main/resources/static/js/board/boardList.js
+++ b/src/main/resources/static/js/board/boardList.js
@@ -1,0 +1,64 @@
+let filters = {}; // 기본적으로 빈 객체
+
+$(document).ready(function () {
+    fetchBoardList(); // 초기 로드
+});
+
+function fetchBoardList() {
+    $.ajax({
+        url: "/api/v1/boards",
+        type: "GET",
+        data: filters,
+    }).done(function(response) {
+        renderBoardList(response.data.content); // 리스트
+        renderPagination("pagination", {
+            page: response.data.page,
+            totalPages: response.data.totalPages,
+            first: response.data.first,
+            last: response.data.last
+        }, (newPage) => {
+            fetchBoardList({ ...filters, page: newPage });
+        });
+    }).fail(handleServerError);
+}
+
+// 게시글 리스트 렌더링
+function renderBoardList(list) {
+    const noticeContainer = $("#notice-list");
+    const boardContainer = $("#board-list");
+
+    noticeContainer.empty();
+    boardContainer.empty();
+
+    if (!list || list.length === 0) {
+        boardContainer.append(`<div class="text-center py-3">등록된 게시글이 없습니다.</div>`);
+        return;
+    }
+
+    list.forEach(board => {
+        const isNotice = board.boardType === "NOTICE";
+        const type = isNotice ? "공지사항" : "건의/문의";
+
+        const row = $(`
+            <div class="d-flex py-2 fw-bold">
+                <div class="col-1 text-center">${board.boardId}</div>
+                <div class="col-1 text-center me-3" style="${isNotice ? 'border: 1px solid rgba(255,0,0,0.5); border-radius: 4px; color: red;' : ''}">
+                    ${type}
+                </div>
+                <div class="col-5" style="${isNotice ? 'color: red;' : ''}">
+                    <a href="/board/${board.boardId}" style="${isNotice ? 'color: red;' : ''}">${board.title}</a>
+                </div>
+                <div class="col-2 text-center">${board.writerName}</div>
+                <div class="col-3 text-center">
+                    ${new Date(board.createdAt).toLocaleDateString()}
+                </div>
+            </div>
+        `);
+
+        if (isNotice) {
+            noticeContainer.append(row);
+        } else {
+            boardContainer.append(row);
+        }
+    });
+}

--- a/src/main/resources/static/js/board/boardRegistration.js
+++ b/src/main/resources/static/js/board/boardRegistration.js
@@ -54,7 +54,7 @@ $(document).ready(function () {
             contentType: false,  // multipart/form-data로 전송
         }).done(function(response) {
             showSnackbar(response.message);
-            window.location.href = '/board/list';
+            window.location.href = '/board';
         }).fail(function(jqXHR) {
             handleServerError(jqXHR);
         })

--- a/src/main/resources/static/js/board/boardRegistration.js
+++ b/src/main/resources/static/js/board/boardRegistration.js
@@ -34,6 +34,11 @@ $(document).ready(function () {
         const content = $('#content').val();
         const files = $('#files')[0].files;
 
+        if (!boardType || !title || !content) {
+            showSnackbar('모든 필드를 입력해주세요.');
+            return;
+        }
+
         // FormData 객체 생성
         const formData = new FormData();
         const data = JSON.stringify({ boardType, title, content });

--- a/src/main/resources/static/js/board/boardRegistration.js
+++ b/src/main/resources/static/js/board/boardRegistration.js
@@ -1,0 +1,62 @@
+$(document).ready(function () {
+    // 파일 선택 시 미리보기
+    $('#files').on('change', function() {
+        const files = Array.from(this.files);
+        const $previewList = $('#filePreviewList');
+        $previewList.empty();
+
+        files.forEach(file => {
+            const listItem = $('<li>')
+                .addClass('list-group-item d-flex justify-content-between align-items-center')
+                .text(file.name);
+
+            const removeBtn = $('<button>')
+                .addClass('btn btn-sm btn-danger')
+                .text('삭제')
+                .on('click', function() {
+                    const dt = new DataTransfer();
+                    Array.from($('#files')[0].files)
+                        .filter(f => f.name !== file.name)
+                        .forEach(f => dt.items.add(f));
+                    $('#files')[0].files = dt.files;
+                    listItem.remove();
+                });
+
+            listItem.append(removeBtn);
+            $previewList.append(listItem);
+        });
+    });
+
+    // 등록 버튼 클릭 (AJAX 등에서 사용)
+    $('#submitBtn').on('click', function() {
+        const boardType = $('#boardType').val();
+        const title = $('#title').val();
+        const content = $('#content').val();
+        const files = $('#files')[0].files;
+
+        // FormData 객체 생성
+        const formData = new FormData();
+        const data = JSON.stringify({ boardType, title, content });
+
+        // JSON 형태의 data를 Blob으로 만들어서 'data'로 추가
+        formData.append('data', new Blob([data], { type: "application/json" }));
+
+        // 파일 추가
+        for (let i = 0; i < files.length; i++) {
+            formData.append('files', files[i]);
+        }
+
+        $.ajax({
+            url: '/api/v1/boards',
+            method: 'POST',
+            data: formData,
+            processData: false,  // jQuery가 데이터를 문자열로 변환하지 않도록
+            contentType: false,  // multipart/form-data로 전송
+        }).done(function(response) {
+            showSnackbar(response.message);
+            window.location.href = '/board/list';
+        }).fail(function(jqXHR) {
+            handleServerError(jqXHR);
+        })
+    });
+});

--- a/src/main/resources/static/js/board/boardUpdate.js
+++ b/src/main/resources/static/js/board/boardUpdate.js
@@ -6,6 +6,48 @@ $(document).ready(function() {
 
     fetchBoardDetail(boardId);
 
+    // 새 파일 선택 시 미리보기 추가
+    $('#files').on('change', function() {
+        const files = Array.from(this.files);
+        const $previewList = $('#filePreviewList');
+
+        files.forEach(file => {
+            // 리스트 아이템 생성
+            const listItem = $('<li>')
+                .addClass('list-group-item d-flex justify-content-between align-items-center');
+
+            // 파일 이름
+            const fileNameSpan = $('<span>').text(file.name);
+
+            // "신규" 배지
+            const newBadge = $('<span>')
+                .addClass('badge bg-success ms-2') // 초록색, margin-left
+                .css('font-size', '0.75rem')      // 작게
+                .text('신규');
+
+            fileNameSpan.append(newBadge);
+
+            // 삭제 버튼
+            const removeBtn = $('<button>')
+                .addClass('btn btn-sm btn-danger')
+                .text('삭제')
+                .on('click', function() {
+                    const dt = new DataTransfer();
+                    Array.from($('#files')[0].files)
+                        .filter(f => f.name !== file.name)
+                        .forEach(f => dt.items.add(f));
+                    $('#files')[0].files = dt.files;
+
+                    listItem.remove();
+                });
+
+            listItem.append(fileNameSpan);
+            listItem.append(removeBtn);
+            $previewList.append(listItem);
+        });
+    });
+
+
     $("#submitBtn").on("click", function() {
         updateBoard(boardId);
     });
@@ -34,7 +76,7 @@ function fetchBoardDetail(boardId) {
                 .addClass('btn btn-sm btn-danger')
                 .text('삭제')
                 .on('click', function() {
-                    deletedFileIds.push(file.id); // 삭제 목록에 추가
+                    deletedFileIds.push(file.fileId); // 삭제 목록에 추가
                     listItem.remove();
                 });
 

--- a/src/main/resources/static/js/board/boardUpdate.js
+++ b/src/main/resources/static/js/board/boardUpdate.js
@@ -1,0 +1,79 @@
+let deletedFileIds = []; // 삭제 요청할 파일 id 저장
+
+$(document).ready(function() {
+    const pathParts = window.location.pathname.split("/");
+    const boardId = pathParts[pathParts.length - 2]; // /board/{id}/update →倒수 2번째가 id
+
+    fetchBoardDetail(boardId);
+
+    $("#submitBtn").on("click", function() {
+        updateBoard(boardId);
+    });
+});
+
+function fetchBoardDetail(boardId) {
+    $.ajax({
+        url: `/api/v1/boards/${boardId}`,
+        type: "GET"
+    }).done(function(response) {
+        const board = response.data;
+        // 폼 채우기
+        $("#boardType").val(board.boardType);
+        $("#title").val(board.title);
+        $("#content").val(board.content);
+
+        // 기존 파일 미리보기
+        const $previewList = $('#filePreviewList');
+        $previewList.empty();
+        board.files.forEach(file => {
+            const listItem = $('<li>')
+                .addClass('list-group-item d-flex justify-content-between align-items-center')
+                .text(file.originalName);
+
+            const removeBtn = $('<button>')
+                .addClass('btn btn-sm btn-danger')
+                .text('삭제')
+                .on('click', function() {
+                    deletedFileIds.push(file.id); // 삭제 목록에 추가
+                    listItem.remove();
+                });
+
+            listItem.append(removeBtn);
+            $previewList.append(listItem);
+        });
+    }).fail(handleServerError);
+}
+
+// 저장 시
+function updateBoard(boardId) {
+    const boardType = $('#boardType').val();
+    const title = $('#title').val();
+    const content = $('#content').val();
+    const files = $('#files')[0].files;
+
+    if (!boardType || !title || !content) {
+        showSnackbar('모든 필드를 입력해주세요.');
+        return;
+    }
+
+    // FormData 객체 생성
+    const formData = new FormData();
+    const data = JSON.stringify({ boardType, title, content, deletedFileIds });
+
+    formData.append('data', new Blob([data], { type: "application/json" }));
+
+    for (let i = 0; i < files.length; i++) {
+        formData.append('files', files[i]);
+    }
+
+    $.ajax({
+        url: `/api/v1/boards/${boardId}`,
+        type: "PATCH",
+        processData: false,
+        contentType: false,
+        data: formData
+    }).done(function() {
+        alert("게시글이 수정되었습니다.");
+        window.location.href = `/board/${boardId}`;
+    }).fail(handleServerError);
+}

--- a/src/main/resources/templates/board/boardDetail.html
+++ b/src/main/resources/templates/board/boardDetail.html
@@ -26,8 +26,13 @@
                     </div>
                 </div>
 
-                <div>
-                    <div id="comment-list">
+                <div class="mt-3">
+                    <div id="comment-list"></div>
+                    <div class="mt-4">
+                        <h5>댓글 작성</h5>
+                        <label for="comment-content"></label>
+                        <textarea id="comment-content" class="form-control mb-2" rows="3"></textarea>
+                        <button id="submit-comment" class="btn btn-success">등록</button>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/board/boardDetail.html
+++ b/src/main/resources/templates/board/boardDetail.html
@@ -28,6 +28,7 @@
 
                 <div class="mt-3">
                     <div id="comment-list"></div>
+                    <div id="comment-pagination" class="mt-2"></div>
                     <div class="mt-4">
                         <h5>댓글 작성</h5>
                         <label for="comment-content"></label>

--- a/src/main/resources/templates/board/boardDetail.html
+++ b/src/main/resources/templates/board/boardDetail.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>EquipRental - 게시글 상세 조회</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/common/common.css">
+</head>
+<body>
+<div class="wrapper">
+    <div class="content-wrapper">
+        {{#isAdmin}}
+        {{> common/adminSidebar }}
+        {{/isAdmin}}
+        {{^isAdmin}}
+        {{> common/userSidebar }}
+        {{/isAdmin}}
+        <main class="content">
+            <div class="container-fluid mt-5">
+                <h2>상세 조회</h2>
+
+            </div>
+        </main>
+    </div>
+</div>
+<div id="snackbar"></div>
+
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/common/common.js"></script>
+<script src="/js/auth/logout.js"></script>
+<script src="/js/board/boardList.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/board/boardDetail.html
+++ b/src/main/resources/templates/board/boardDetail.html
@@ -21,7 +21,15 @@
         <main class="content">
             <div class="container-fluid mt-5">
                 <h2>상세 조회</h2>
+                <div>
+                    <div id="board-detail">
+                    </div>
+                </div>
 
+                <div>
+                    <div id="comment-list">
+                    </div>
+                </div>
             </div>
         </main>
     </div>
@@ -32,6 +40,6 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="/js/common/common.js"></script>
 <script src="/js/auth/logout.js"></script>
-<script src="/js/board/boardList.js"></script>
+<script src="/js/board/boardDetail.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/board/boardList.html
+++ b/src/main/resources/templates/board/boardList.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>EquipRental - 건의/문의 게시판</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/common/common.css">
+</head>
+<body>
+<div class="wrapper">
+    <div class="content-wrapper">
+        {{#isAdmin}}
+            {{> common/adminSidebar }}
+        {{/isAdmin}}
+        {{^isAdmin}}
+            {{> common/userSidebar }}
+        {{/isAdmin}}
+        <main class="content">
+            <div class="container-fluid mt-5">
+                <h2>건의/문의 게시판</h2>
+            </div>
+        </main>
+    </div>
+</div>
+<div id="snackbar"></div>
+
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/common/common.js"></script>
+<script src="/js/auth/logout.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/board/boardList.html
+++ b/src/main/resources/templates/board/boardList.html
@@ -42,6 +42,7 @@
 
                 <!-- 글 등록 버튼 -->
                 <div class="d-flex justify-content-end mt-3">
+                    <button id="toggleNoticeBtn" class="btn btn-outline-secondary me-3">공지사항만 보기</button>
                     <a href="/board/registration" class="btn btn-primary">글 등록</a>
                 </div>
 

--- a/src/main/resources/templates/board/boardList.html
+++ b/src/main/resources/templates/board/boardList.html
@@ -40,10 +40,27 @@
                     </div>
                 </div>
 
-                <!-- 글 등록 버튼 -->
-                <div class="d-flex justify-content-end mt-3">
-                    <button id="toggleNoticeBtn" class="btn btn-outline-secondary me-3">공지사항만 보기</button>
-                    <a href="/board/registration" class="btn btn-primary">글 등록</a>
+                <div class="d-flex justify-content-between align-items-center mt-3">
+                    <!-- 좌측: 공지사항 토글 버튼 -->
+                    <div>
+                        <button id="toggleNoticeBtn" class="btn btn-outline-secondary">공지사항만 보기</button>
+                    </div>
+
+                    <!-- 중앙: 검색창 -->
+                    <div class="flex-grow-1 mx-3 d-flex" style="max-width: 500px;">
+                        <label for="search-type"></label>
+                        <select id="search-type" class="form-select me-2" style="max-width: 120px;">
+                            <option value="title" selected>제목</option>
+                            <option value="writer">작성자</option>
+                        </select>
+                        <label for="search-keyword"></label>
+                        <input type="text" id="search-keyword" class="form-control" placeholder="검색어 입력">
+                    </div>
+
+                    <!-- 우측: 글 등록 버튼 -->
+                    <div>
+                        <a href="/board/registration" class="btn btn-primary">글 등록</a>
+                    </div>
                 </div>
 
                 <!-- 페이징 -->

--- a/src/main/resources/templates/board/boardList.html
+++ b/src/main/resources/templates/board/boardList.html
@@ -21,8 +21,33 @@
         <main class="content">
             <div class="container-fluid mt-5">
                 <h2>건의/문의 게시판</h2>
+
+                <!-- 공지 영역 -->
+                <div class="bg-light">
+                    <div class="d-flex fw-bold border-bottom pb-2 list-header">
+                        <div class="col-1 text-center">ID</div>
+                        <div class="col-1 text-center me-3">글 타입</div>
+                        <div class="col-5">제목</div>
+                        <div class="col-2 text-center">작성자</div>
+                        <div class="col-3 text-center">작성일</div>
+                    </div>
+                    <div id="notice-list" class="mb-3">
+                        <!-- 공지글 렌더링 -->
+                    </div>
+                    <!-- 일반글 영역 -->
+                    <div id="board-list" class="mt-3 mb-3">
+                        <!-- 일반 글 렌더링 -->
+                    </div>
+                </div>
+
                 <!-- 글 등록 버튼 -->
-                <a href="/board/registration" class="btn btn-primary">글 등록</a>
+                <div class="d-flex justify-content-end mt-3">
+                    <a href="/board/registration" class="btn btn-primary">글 등록</a>
+                </div>
+
+                <!-- 페이징 -->
+                <div id="pagination" class="mt-3"></div>
+
             </div>
         </main>
     </div>

--- a/src/main/resources/templates/board/boardList.html
+++ b/src/main/resources/templates/board/boardList.html
@@ -21,6 +21,8 @@
         <main class="content">
             <div class="container-fluid mt-5">
                 <h2>건의/문의 게시판</h2>
+                <!-- 글 등록 버튼 -->
+                <a href="/board/registration" class="btn btn-primary">글 등록</a>
             </div>
         </main>
     </div>
@@ -31,5 +33,6 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="/js/common/common.js"></script>
 <script src="/js/auth/logout.js"></script>
+<script src="/js/board/boardList.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/board/boardRegistration.html
+++ b/src/main/resources/templates/board/boardRegistration.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>EquipRental - 게시글 등록</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/common/common.css">
+</head>
+<body>
+<div class="wrapper">
+    <div class="content-wrapper">
+        {{#isAdmin}}
+        {{> common/adminSidebar }}
+        {{/isAdmin}}
+        {{^isAdmin}}
+        {{> common/userSidebar }}
+        {{/isAdmin}}
+        <main class="content">
+            <div class="container-fluid mt-5">
+                <h2>게시글 등록</h2>
+                <!-- 게시판 타입 선택 -->
+                <div class="mb-3">
+                    <label for="boardType" class="form-label">게시판 타입</label>
+                    <select class="form-select" id="boardType">
+                        {{#isAdmin}}
+                        <option value="SUGGESTION">건의/문의</option>
+                        <option value="NOTICE">공지사항</option>
+                        {{/isAdmin}}
+                        {{^isAdmin}}
+                        <option value="SUGGESTION">건의/문의</option>
+                        {{/isAdmin}}
+                    </select>
+                </div>
+
+                <!-- 제목 입력 -->
+                <div class="mb-3">
+                    <label for="title" class="form-label">제목</label>
+                    <input type="text" class="form-control" id="title" placeholder="제목을 입력하세요" required>
+                </div>
+
+                <!-- 내용 입력 -->
+                <div class="mb-3">
+                    <label for="content" class="form-label">내용</label>
+                    <textarea class="form-control" id="content" rows="6" placeholder="내용을 입력하세요" required></textarea>
+                </div>
+
+                <!-- 파일 업로드 -->
+                <div class="mb-3">
+                    <label for="files" class="form-label">첨부파일</label>
+                    <input class="form-control" type="file" id="files" multiple>
+                    <ul id="filePreviewList" class="list-group mt-2"></ul>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button id="submitBtn" class="btn btn-primary">등록</button>
+                    <a href="/board/list" class="btn btn-secondary">취소</a>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+<div id="snackbar"></div>
+
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/common/common.js"></script>
+<script src="/js/auth/logout.js"></script>
+<script src="/js/board/boardRegistration.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/board/boardRegistration.html
+++ b/src/main/resources/templates/board/boardRegistration.html
@@ -56,7 +56,7 @@
 
                 <div class="d-flex gap-2">
                     <button id="submitBtn" class="btn btn-primary">등록</button>
-                    <a href="/board/list" class="btn btn-secondary">취소</a>
+                    <a href="/board" class="btn btn-secondary">취소</a>
                 </div>
             </div>
         </main>

--- a/src/main/resources/templates/board/boardUpdate.html
+++ b/src/main/resources/templates/board/boardUpdate.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>EquipRental - 게시글 수정</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/common/common.css">
+</head>
+<body>
+<div class="wrapper">
+    <div class="content-wrapper">
+        {{#isAdmin}}
+        {{> common/adminSidebar }}
+        {{/isAdmin}}
+        {{^isAdmin}}
+        {{> common/userSidebar }}
+        {{/isAdmin}}
+        <main class="content">
+            <div class="container-fluid mt-5">
+                <h2>게시글 수정</h2>
+                <!-- 게시판 타입 선택 -->
+                <div class="mb-3">
+                    <label for="boardType" class="form-label">게시판 타입</label>
+                    <select class="form-select" id="boardType">
+                        {{#isAdmin}}
+                        <option value="SUGGESTION">건의/문의</option>
+                        <option value="NOTICE">공지사항</option>
+                        {{/isAdmin}}
+                        {{^isAdmin}}
+                        <option value="SUGGESTION">건의/문의</option>
+                        {{/isAdmin}}
+                    </select>
+                </div>
+
+                <!-- 제목 입력 -->
+                <div class="mb-3">
+                    <label for="title" class="form-label">제목</label>
+                    <input type="text" class="form-control" id="title" placeholder="제목을 입력하세요" required>
+                </div>
+
+                <!-- 내용 입력 -->
+                <div class="mb-3">
+                    <label for="content" class="form-label">내용</label>
+                    <textarea class="form-control" id="content" rows="6" placeholder="내용을 입력하세요" required></textarea>
+                </div>
+
+                <!-- 파일 업로드 -->
+                <div class="mb-3">
+                    <label for="files" class="form-label">첨부파일</label>
+                    <input class="form-control" type="file" id="files" multiple>
+                    <ul id="filePreviewList" class="list-group mt-2"></ul>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button id="submitBtn" class="btn btn-primary">등록</button>
+                    <button type="button" class="btn btn-secondary" onclick="history.back()">취소</button>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+<div id="snackbar"></div>
+
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/common/common.js"></script>
+<script src="/js/auth/logout.js"></script>
+<script src="/js/board/boardUpdate.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/common/adminSidebar.html
+++ b/src/main/resources/templates/common/adminSidebar.html
@@ -29,7 +29,7 @@
             </div>
         </li>
         <li>
-            <a href="/board/list" class="nav-link active">
+            <a href="/board" class="nav-link active">
                 건의/문의 게시판
             </a>
         </li>

--- a/src/main/resources/templates/common/adminSidebar.html
+++ b/src/main/resources/templates/common/adminSidebar.html
@@ -29,8 +29,8 @@
             </div>
         </li>
         <li>
-            <a href="/board" class="nav-link active">
-                발품 신청
+            <a href="/board/list" class="nav-link active">
+                건의/문의 게시판
             </a>
         </li>
         <li>

--- a/src/main/resources/templates/common/adminSidebar.html
+++ b/src/main/resources/templates/common/adminSidebar.html
@@ -1,6 +1,6 @@
 <nav class="sidebar d-flex flex-column p-3 border-end" style="width: 220px; height: 100%;">
     <a href="/home" class="logo">EquipRental</a>
-    <ul class="nav nav-pills flex-column mb-auto">
+    <ul class="nav nav-pills flex-column mb-auto text-center">
         <li>
             <a href="/home" class="nav-link active">
                 홈
@@ -30,7 +30,7 @@
         </li>
         <li>
             <a href="/board" class="nav-link active">
-                건의/문의 게시판
+                FAQ
             </a>
         </li>
         <li>

--- a/src/main/resources/templates/common/userSidebar.html
+++ b/src/main/resources/templates/common/userSidebar.html
@@ -12,8 +12,8 @@
             </a>
         </li>
         <li>
-            <a href="/board" class="nav-link active">
-                발품 신청
+            <a href="/board/list" class="nav-link active">
+                건의/문의 게시판
             </a>
         </li>
     </ul>

--- a/src/main/resources/templates/common/userSidebar.html
+++ b/src/main/resources/templates/common/userSidebar.html
@@ -12,7 +12,7 @@
             </a>
         </li>
         <li>
-            <a href="/board/list" class="nav-link active">
+            <a href="/board" class="nav-link active">
                 건의/문의 게시판
             </a>
         </li>

--- a/src/main/resources/templates/common/userSidebar.html
+++ b/src/main/resources/templates/common/userSidebar.html
@@ -1,6 +1,6 @@
 <nav class="sidebar d-flex flex-column p-3 border-end" style="width: 220px; height: 100%;">
     <a href="/home" class="logo">EquipRental</a>
-    <ul class="nav nav-pills flex-column mb-auto">
+    <ul class="nav nav-pills flex-column mb-auto text-center">
         <li>
             <a href="/equipment/list" class="nav-link active">
                 장비 조회
@@ -13,7 +13,7 @@
         </li>
         <li>
             <a href="/board" class="nav-link active">
-                건의/문의 게시판
+                FAQ
             </a>
         </li>
     </ul>

--- a/src/test/java/com/equip/equiprental/auth/AuthServiceImplTest.java
+++ b/src/test/java/com/equip/equiprental/auth/AuthServiceImplTest.java
@@ -1,179 +1,189 @@
-//package com.equip.equiprental.auth;
-//
-//import com.equip.equiprental.auth.service.AuthServiceImpl;
-//import com.equip.equiprental.auth.security.PrincipalDetails;
-//import com.equip.equiprental.common.exception.CustomException;
-//import com.equip.equiprental.common.exception.ErrorType;
-//import com.equip.equiprental.member.domain.Member;
-//import com.equip.equiprental.member.domain.MemberRole;
-//import com.equip.equiprental.member.domain.MemberStatus;
-//import com.equip.equiprental.auth.dto.LoginRequestDto;
-//import com.equip.equiprental.auth.dto.LoginResponseDto;
-//import jakarta.servlet.http.Cookie;
-//import jakarta.servlet.http.HttpServletRequest;
-//import jakarta.servlet.http.HttpServletResponse;
-//import jakarta.servlet.http.HttpSession;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.security.authentication.AuthenticationManager;
-//import org.springframework.security.authentication.BadCredentialsException;
-//import org.springframework.security.authentication.DisabledException;
-//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-//import org.springframework.security.core.Authentication;
-//import org.springframework.security.core.context.SecurityContextHolder;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.assertj.core.api.Assertions.assertThatThrownBy;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.*;
-//import static org.mockito.Mockito.when;
-//
-//@ExtendWith(MockitoExtension.class)
-//@DisplayName("AuthServiceImpl 단위 테스트")
-//public class AuthServiceImplTest {
-//    @Mock
-//    private AuthenticationManager authenticationManager;
-//    @Mock private HttpServletRequest httpRequest;
-//    @Mock private HttpServletResponse httpResponse;
-//    @Mock private HttpSession httpSession;
-//    @Mock private Authentication authentication;
-//
-//    @InjectMocks
-//    private AuthServiceImpl authService;
-//
-//    @Nested
-//    @DisplayName("login() 메서드 테스트")
-//    class login {
-//        @Test
-//        @DisplayName("성공 - 로그인 성공")
-//        void login_success() {
-//            // given
-//            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
-//            Member member = Member.builder()
-//                    .memberId(1L)
-//                    .username("testUser")
-//                    .name("테스트")
-//                    .department("개발")
-//                    .email("test@example.com")
-//                    .role(MemberRole.USER)
-//                    .status(MemberStatus.ACTIVE) // 여기 주의: ACTIVE로 세팅
-//                    .build();
-//            PrincipalDetails principal = new PrincipalDetails(member);
-//
-//            when(httpRequest.getSession(true)).thenReturn(httpSession);
-//            when(authentication.getPrincipal()).thenReturn(principal);
-//            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-//                    .thenReturn(authentication);
-//
-//            // when
-//            LoginResponseDto response = authService.login(httpRequest, dto);
-//
-//            // then
-//            assertThat(response.getMemberId()).isEqualTo(1L);
-//            assertThat(response.getUsername()).isEqualTo("testUser");
-//            assertThat(response.getName()).isEqualTo("테스트");
-//            assertThat(response.getDepartment()).isEqualTo("개발");
-//            assertThat(response.getEmail()).isEqualTo("test@example.com");
-//            assertThat(response.getRole()).isEqualTo("USER");
-//            assertThat(response.getStatus()).isEqualTo("ACTIVE");
-//
-//            verify(httpSession, times(1))
-//                    .setAttribute(any(), any());
-//        }
-//
-//        @Test
-//        @DisplayName("예외 - 로그인 비밀번호 불일치")
-//        void login_badCredentials() {
-//            LoginRequestDto dto = new LoginRequestDto("testUser", "wrongPassword");
-//
-//            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-//                    .thenThrow(new BadCredentialsException("Bad credentials"));
-//
-//            assertThatThrownBy(() -> authService.login(httpRequest, dto))
-//                    .isInstanceOf(CustomException.class)
-//                    .extracting("errorType")
-//                    .isEqualTo(ErrorType.BAD_CREDENTIALS);
-//        }
-//
-//        @Test
-//        @DisplayName("예외 - 사용자 비활성화 (USER_DELETED)")
-//        void login_disabledUserDeleted() {
-//            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
-//
-//            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-//                    .thenThrow(new DisabledException("USER_DELETED"));
-//
-//            assertThatThrownBy(() -> authService.login(httpRequest, dto))
-//                    .isInstanceOf(CustomException.class)
-//                    .extracting("errorType")
-//                    .isEqualTo(ErrorType.USER_DELETED);
-//        }
-//
-//        @Test
-//        @DisplayName("예외 - 사용자 미승인 (USER_PENDING)")
-//        void login_disabledUserInactive() {
-//            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
-//
-//            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-//                    .thenThrow(new DisabledException("USER_PENDING"));
-//
-//            assertThatThrownBy(() -> authService.login(httpRequest, dto))
-//                    .isInstanceOf(CustomException.class)
-//                    .extracting("errorType")
-//                    .isEqualTo(ErrorType.USER_PENDING);
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("logout() 메서드 테스트")
-//    class logout {
-//        @Test
-//        @DisplayName("성공 - 로그아웃 시 세션 무효화, SecurityContext 초기화, JSESSIONID 쿠키 삭제")
-//        void logout_success() {
-//            // given
-//            when(httpRequest.getSession(false)).thenReturn(httpSession);
-//            Cookie jsessionCookie = new Cookie("JSESSIONID", "12345");
-//            when(httpRequest.getCookies()).thenReturn(new Cookie[]{jsessionCookie});
-//
-//            // SecurityContext에 임의 인증 정보 설정
-//            SecurityContextHolder.getContext().setAuthentication(mock(org.springframework.security.core.Authentication.class));
-//
-//            // when
-//            authService.logout(httpRequest, httpResponse);
-//
-//            // then
-//            // 세션 무효화 확인
-//            verify(httpSession).invalidate();
-//
-//            // SecurityContext 초기화 확인
-//            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-//
-//            // 쿠키 삭제 확인
-//            verify(httpResponse).addCookie(argThat(cookie ->
-//                    "JSESSIONID".equals(cookie.getName()) &&
-//                            cookie.getMaxAge() == 0 &&
-//                            cookie.getValue() == null
-//            ));
-//        }
-//
-//        @Test
-//        @DisplayName("세션이 없는 경우 - logout() 호출 시 아무 동작 없음")
-//        void logout_noSession() {
-//            when(httpRequest.getSession(false)).thenReturn(null);
-//            when(httpRequest.getCookies()).thenReturn(null);
-//
-//            authService.logout(httpRequest, httpResponse);
-//
-//            // 세션 invalidate 호출 안 됨
-//            verify(httpSession, never()).invalidate();
-//
-//            // 쿠키 삭제도 없음
-//            verify(httpResponse, never()).addCookie(any());
-//        }
-//    }
-//}
+package com.equip.equiprental.auth;
+
+import com.equip.equiprental.auth.service.AuthServiceImpl;
+import com.equip.equiprental.auth.security.PrincipalDetails;
+import com.equip.equiprental.common.exception.CustomException;
+import com.equip.equiprental.common.exception.ErrorType;
+import com.equip.equiprental.member.domain.Department;
+import com.equip.equiprental.member.domain.Member;
+import com.equip.equiprental.member.domain.MemberRole;
+import com.equip.equiprental.member.domain.MemberStatus;
+import com.equip.equiprental.auth.dto.LoginRequestDto;
+import com.equip.equiprental.auth.dto.LoginResponseDto;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthServiceImpl 단위 테스트")
+public class AuthServiceImplTest {
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock private HttpServletRequest httpRequest;
+    @Mock private HttpServletResponse httpResponse;
+    @Mock private HttpSession httpSession;
+    @Mock private Authentication authentication;
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    @Nested
+    @DisplayName("login() 메서드 테스트")
+    class login {
+        private Department mockDepartment;
+
+        @BeforeEach
+        void setUp() {
+            mockDepartment = new Department(1L, "testdepartment");
+        }
+
+        @Test
+        @DisplayName("성공 - 로그인 성공")
+        void login_success() {
+            // given
+
+            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
+            Member member = Member.builder()
+                    .memberId(1L)
+                    .username("testUser")
+                    .name("테스트")
+                    .department(mockDepartment)
+                    .email("test@example.com")
+                    .role(MemberRole.USER)
+                    .status(MemberStatus.ACTIVE) // 여기 주의: ACTIVE로 세팅
+                    .build();
+            PrincipalDetails principal = new PrincipalDetails(member);
+
+            when(httpRequest.getSession(true)).thenReturn(httpSession);
+            when(authentication.getPrincipal()).thenReturn(principal);
+            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                    .thenReturn(authentication);
+
+            // when
+            LoginResponseDto response = authService.login(httpRequest, dto);
+
+            // then
+            assertThat(response.getMemberId()).isEqualTo(1L);
+            assertThat(response.getUsername()).isEqualTo("testUser");
+            assertThat(response.getName()).isEqualTo("테스트");
+            assertThat(response.getDepartment()).isEqualTo("testdepartment");
+            assertThat(response.getEmail()).isEqualTo("test@example.com");
+            assertThat(response.getRole()).isEqualTo("USER");
+            assertThat(response.getStatus()).isEqualTo("ACTIVE");
+
+            verify(httpSession, times(1))
+                    .setAttribute(any(), any());
+        }
+
+        @Test
+        @DisplayName("예외 - 로그인 비밀번호 불일치")
+        void login_badCredentials() {
+            LoginRequestDto dto = new LoginRequestDto("testUser", "wrongPassword");
+
+            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                    .thenThrow(new BadCredentialsException("Bad credentials"));
+
+            assertThatThrownBy(() -> authService.login(httpRequest, dto))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.BAD_CREDENTIALS);
+        }
+
+        @Test
+        @DisplayName("예외 - 사용자 비활성화 (USER_DELETED)")
+        void login_disabledUserDeleted() {
+            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
+
+            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                    .thenThrow(new DisabledException("USER_DELETED"));
+
+            assertThatThrownBy(() -> authService.login(httpRequest, dto))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.USER_DELETED);
+        }
+
+        @Test
+        @DisplayName("예외 - 사용자 미승인 (USER_PENDING)")
+        void login_disabledUserInactive() {
+            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
+
+            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                    .thenThrow(new DisabledException("USER_PENDING"));
+
+            assertThatThrownBy(() -> authService.login(httpRequest, dto))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.USER_PENDING);
+        }
+    }
+
+    @Nested
+    @DisplayName("logout() 메서드 테스트")
+    class logout {
+        @Test
+        @DisplayName("성공 - 로그아웃 시 세션 무효화, SecurityContext 초기화, JSESSIONID 쿠키 삭제")
+        void logout_success() {
+            // given
+            when(httpRequest.getSession(false)).thenReturn(httpSession);
+            Cookie jsessionCookie = new Cookie("JSESSIONID", "12345");
+            when(httpRequest.getCookies()).thenReturn(new Cookie[]{jsessionCookie});
+
+            // SecurityContext에 임의 인증 정보 설정
+            SecurityContextHolder.getContext().setAuthentication(mock(org.springframework.security.core.Authentication.class));
+
+            // when
+            authService.logout(httpRequest, httpResponse);
+
+            // then
+            // 세션 무효화 확인
+            verify(httpSession).invalidate();
+
+            // SecurityContext 초기화 확인
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+
+            // 쿠키 삭제 확인
+            verify(httpResponse).addCookie(argThat(cookie ->
+                    "JSESSIONID".equals(cookie.getName()) &&
+                            cookie.getMaxAge() == 0 &&
+                            cookie.getValue() == null
+            ));
+        }
+
+        @Test
+        @DisplayName("세션이 없는 경우 - logout() 호출 시 아무 동작 없음")
+        void logout_noSession() {
+            when(httpRequest.getSession(false)).thenReturn(null);
+            when(httpRequest.getCookies()).thenReturn(null);
+
+            authService.logout(httpRequest, httpResponse);
+
+            // 세션 invalidate 호출 안 됨
+            verify(httpSession, never()).invalidate();
+
+            // 쿠키 삭제도 없음
+            verify(httpResponse, never()).addCookie(any());
+        }
+    }
+}

--- a/src/test/java/com/equip/equiprental/auth/AuthServiceImplTest.java
+++ b/src/test/java/com/equip/equiprental/auth/AuthServiceImplTest.java
@@ -1,179 +1,179 @@
-package com.equip.equiprental.auth;
-
-import com.equip.equiprental.auth.service.AuthServiceImpl;
-import com.equip.equiprental.auth.security.PrincipalDetails;
-import com.equip.equiprental.common.exception.CustomException;
-import com.equip.equiprental.common.exception.ErrorType;
-import com.equip.equiprental.member.domain.Member;
-import com.equip.equiprental.member.domain.MemberRole;
-import com.equip.equiprental.member.domain.MemberStatus;
-import com.equip.equiprental.auth.dto.LoginRequestDto;
-import com.equip.equiprental.auth.dto.LoginResponseDto;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.DisabledException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.when;
-
-@ExtendWith(MockitoExtension.class)
-@DisplayName("AuthServiceImpl 단위 테스트")
-public class AuthServiceImplTest {
-    @Mock
-    private AuthenticationManager authenticationManager;
-    @Mock private HttpServletRequest httpRequest;
-    @Mock private HttpServletResponse httpResponse;
-    @Mock private HttpSession httpSession;
-    @Mock private Authentication authentication;
-
-    @InjectMocks
-    private AuthServiceImpl authService;
-
-    @Nested
-    @DisplayName("login() 메서드 테스트")
-    class login {
-        @Test
-        @DisplayName("성공 - 로그인 성공")
-        void login_success() {
-            // given
-            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
-            Member member = Member.builder()
-                    .memberId(1L)
-                    .username("testUser")
-                    .name("테스트")
-                    .department("개발")
-                    .email("test@example.com")
-                    .role(MemberRole.USER)
-                    .status(MemberStatus.ACTIVE) // 여기 주의: ACTIVE로 세팅
-                    .build();
-            PrincipalDetails principal = new PrincipalDetails(member);
-
-            when(httpRequest.getSession(true)).thenReturn(httpSession);
-            when(authentication.getPrincipal()).thenReturn(principal);
-            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                    .thenReturn(authentication);
-
-            // when
-            LoginResponseDto response = authService.login(httpRequest, dto);
-
-            // then
-            assertThat(response.getMemberId()).isEqualTo(1L);
-            assertThat(response.getUsername()).isEqualTo("testUser");
-            assertThat(response.getName()).isEqualTo("테스트");
-            assertThat(response.getDepartment()).isEqualTo("개발");
-            assertThat(response.getEmail()).isEqualTo("test@example.com");
-            assertThat(response.getRole()).isEqualTo("USER");
-            assertThat(response.getStatus()).isEqualTo("ACTIVE");
-
-            verify(httpSession, times(1))
-                    .setAttribute(any(), any());
-        }
-
-        @Test
-        @DisplayName("예외 - 로그인 비밀번호 불일치")
-        void login_badCredentials() {
-            LoginRequestDto dto = new LoginRequestDto("testUser", "wrongPassword");
-
-            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                    .thenThrow(new BadCredentialsException("Bad credentials"));
-
-            assertThatThrownBy(() -> authService.login(httpRequest, dto))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorType")
-                    .isEqualTo(ErrorType.BAD_CREDENTIALS);
-        }
-
-        @Test
-        @DisplayName("예외 - 사용자 비활성화 (USER_DELETED)")
-        void login_disabledUserDeleted() {
-            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
-
-            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                    .thenThrow(new DisabledException("USER_DELETED"));
-
-            assertThatThrownBy(() -> authService.login(httpRequest, dto))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorType")
-                    .isEqualTo(ErrorType.USER_DELETED);
-        }
-
-        @Test
-        @DisplayName("예외 - 사용자 미승인 (USER_PENDING)")
-        void login_disabledUserInactive() {
-            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
-
-            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                    .thenThrow(new DisabledException("USER_PENDING"));
-
-            assertThatThrownBy(() -> authService.login(httpRequest, dto))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorType")
-                    .isEqualTo(ErrorType.USER_PENDING);
-        }
-    }
-
-    @Nested
-    @DisplayName("logout() 메서드 테스트")
-    class logout {
-        @Test
-        @DisplayName("성공 - 로그아웃 시 세션 무효화, SecurityContext 초기화, JSESSIONID 쿠키 삭제")
-        void logout_success() {
-            // given
-            when(httpRequest.getSession(false)).thenReturn(httpSession);
-            Cookie jsessionCookie = new Cookie("JSESSIONID", "12345");
-            when(httpRequest.getCookies()).thenReturn(new Cookie[]{jsessionCookie});
-
-            // SecurityContext에 임의 인증 정보 설정
-            SecurityContextHolder.getContext().setAuthentication(mock(org.springframework.security.core.Authentication.class));
-
-            // when
-            authService.logout(httpRequest, httpResponse);
-
-            // then
-            // 세션 무효화 확인
-            verify(httpSession).invalidate();
-
-            // SecurityContext 초기화 확인
-            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-
-            // 쿠키 삭제 확인
-            verify(httpResponse).addCookie(argThat(cookie ->
-                    "JSESSIONID".equals(cookie.getName()) &&
-                            cookie.getMaxAge() == 0 &&
-                            cookie.getValue() == null
-            ));
-        }
-
-        @Test
-        @DisplayName("세션이 없는 경우 - logout() 호출 시 아무 동작 없음")
-        void logout_noSession() {
-            when(httpRequest.getSession(false)).thenReturn(null);
-            when(httpRequest.getCookies()).thenReturn(null);
-
-            authService.logout(httpRequest, httpResponse);
-
-            // 세션 invalidate 호출 안 됨
-            verify(httpSession, never()).invalidate();
-
-            // 쿠키 삭제도 없음
-            verify(httpResponse, never()).addCookie(any());
-        }
-    }
-}
+//package com.equip.equiprental.auth;
+//
+//import com.equip.equiprental.auth.service.AuthServiceImpl;
+//import com.equip.equiprental.auth.security.PrincipalDetails;
+//import com.equip.equiprental.common.exception.CustomException;
+//import com.equip.equiprental.common.exception.ErrorType;
+//import com.equip.equiprental.member.domain.Member;
+//import com.equip.equiprental.member.domain.MemberRole;
+//import com.equip.equiprental.member.domain.MemberStatus;
+//import com.equip.equiprental.auth.dto.LoginRequestDto;
+//import com.equip.equiprental.auth.dto.LoginResponseDto;
+//import jakarta.servlet.http.Cookie;
+//import jakarta.servlet.http.HttpServletRequest;
+//import jakarta.servlet.http.HttpServletResponse;
+//import jakarta.servlet.http.HttpSession;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Nested;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.security.authentication.AuthenticationManager;
+//import org.springframework.security.authentication.BadCredentialsException;
+//import org.springframework.security.authentication.DisabledException;
+//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+//import org.springframework.security.core.Authentication;
+//import org.springframework.security.core.context.SecurityContextHolder;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.assertj.core.api.Assertions.assertThatThrownBy;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.Mockito.*;
+//import static org.mockito.Mockito.when;
+//
+//@ExtendWith(MockitoExtension.class)
+//@DisplayName("AuthServiceImpl 단위 테스트")
+//public class AuthServiceImplTest {
+//    @Mock
+//    private AuthenticationManager authenticationManager;
+//    @Mock private HttpServletRequest httpRequest;
+//    @Mock private HttpServletResponse httpResponse;
+//    @Mock private HttpSession httpSession;
+//    @Mock private Authentication authentication;
+//
+//    @InjectMocks
+//    private AuthServiceImpl authService;
+//
+//    @Nested
+//    @DisplayName("login() 메서드 테스트")
+//    class login {
+//        @Test
+//        @DisplayName("성공 - 로그인 성공")
+//        void login_success() {
+//            // given
+//            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
+//            Member member = Member.builder()
+//                    .memberId(1L)
+//                    .username("testUser")
+//                    .name("테스트")
+//                    .department("개발")
+//                    .email("test@example.com")
+//                    .role(MemberRole.USER)
+//                    .status(MemberStatus.ACTIVE) // 여기 주의: ACTIVE로 세팅
+//                    .build();
+//            PrincipalDetails principal = new PrincipalDetails(member);
+//
+//            when(httpRequest.getSession(true)).thenReturn(httpSession);
+//            when(authentication.getPrincipal()).thenReturn(principal);
+//            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+//                    .thenReturn(authentication);
+//
+//            // when
+//            LoginResponseDto response = authService.login(httpRequest, dto);
+//
+//            // then
+//            assertThat(response.getMemberId()).isEqualTo(1L);
+//            assertThat(response.getUsername()).isEqualTo("testUser");
+//            assertThat(response.getName()).isEqualTo("테스트");
+//            assertThat(response.getDepartment()).isEqualTo("개발");
+//            assertThat(response.getEmail()).isEqualTo("test@example.com");
+//            assertThat(response.getRole()).isEqualTo("USER");
+//            assertThat(response.getStatus()).isEqualTo("ACTIVE");
+//
+//            verify(httpSession, times(1))
+//                    .setAttribute(any(), any());
+//        }
+//
+//        @Test
+//        @DisplayName("예외 - 로그인 비밀번호 불일치")
+//        void login_badCredentials() {
+//            LoginRequestDto dto = new LoginRequestDto("testUser", "wrongPassword");
+//
+//            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+//                    .thenThrow(new BadCredentialsException("Bad credentials"));
+//
+//            assertThatThrownBy(() -> authService.login(httpRequest, dto))
+//                    .isInstanceOf(CustomException.class)
+//                    .extracting("errorType")
+//                    .isEqualTo(ErrorType.BAD_CREDENTIALS);
+//        }
+//
+//        @Test
+//        @DisplayName("예외 - 사용자 비활성화 (USER_DELETED)")
+//        void login_disabledUserDeleted() {
+//            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
+//
+//            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+//                    .thenThrow(new DisabledException("USER_DELETED"));
+//
+//            assertThatThrownBy(() -> authService.login(httpRequest, dto))
+//                    .isInstanceOf(CustomException.class)
+//                    .extracting("errorType")
+//                    .isEqualTo(ErrorType.USER_DELETED);
+//        }
+//
+//        @Test
+//        @DisplayName("예외 - 사용자 미승인 (USER_PENDING)")
+//        void login_disabledUserInactive() {
+//            LoginRequestDto dto = new LoginRequestDto("testUser", "password");
+//
+//            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+//                    .thenThrow(new DisabledException("USER_PENDING"));
+//
+//            assertThatThrownBy(() -> authService.login(httpRequest, dto))
+//                    .isInstanceOf(CustomException.class)
+//                    .extracting("errorType")
+//                    .isEqualTo(ErrorType.USER_PENDING);
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("logout() 메서드 테스트")
+//    class logout {
+//        @Test
+//        @DisplayName("성공 - 로그아웃 시 세션 무효화, SecurityContext 초기화, JSESSIONID 쿠키 삭제")
+//        void logout_success() {
+//            // given
+//            when(httpRequest.getSession(false)).thenReturn(httpSession);
+//            Cookie jsessionCookie = new Cookie("JSESSIONID", "12345");
+//            when(httpRequest.getCookies()).thenReturn(new Cookie[]{jsessionCookie});
+//
+//            // SecurityContext에 임의 인증 정보 설정
+//            SecurityContextHolder.getContext().setAuthentication(mock(org.springframework.security.core.Authentication.class));
+//
+//            // when
+//            authService.logout(httpRequest, httpResponse);
+//
+//            // then
+//            // 세션 무효화 확인
+//            verify(httpSession).invalidate();
+//
+//            // SecurityContext 초기화 확인
+//            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+//
+//            // 쿠키 삭제 확인
+//            verify(httpResponse).addCookie(argThat(cookie ->
+//                    "JSESSIONID".equals(cookie.getName()) &&
+//                            cookie.getMaxAge() == 0 &&
+//                            cookie.getValue() == null
+//            ));
+//        }
+//
+//        @Test
+//        @DisplayName("세션이 없는 경우 - logout() 호출 시 아무 동작 없음")
+//        void logout_noSession() {
+//            when(httpRequest.getSession(false)).thenReturn(null);
+//            when(httpRequest.getCookies()).thenReturn(null);
+//
+//            authService.logout(httpRequest, httpResponse);
+//
+//            // 세션 invalidate 호출 안 됨
+//            verify(httpSession, never()).invalidate();
+//
+//            // 쿠키 삭제도 없음
+//            verify(httpResponse, never()).addCookie(any());
+//        }
+//    }
+//}

--- a/src/test/java/com/equip/equiprental/equipment/service/EquipmentItemServiceImplTest.java
+++ b/src/test/java/com/equip/equiprental/equipment/service/EquipmentItemServiceImplTest.java
@@ -1,227 +1,227 @@
-package com.equip.equiprental.equipment.service;
-
-import com.equip.equiprental.common.dto.PageResponseDto;
-import com.equip.equiprental.common.dto.SearchParamDto;
-import com.equip.equiprental.common.exception.CustomException;
-import com.equip.equiprental.common.exception.ErrorType;
-import com.equip.equiprental.equipment.domain.EquipmentItem;
-import com.equip.equiprental.equipment.domain.EquipmentItemHistory;
-import com.equip.equiprental.equipment.domain.EquipmentStatus;
-import com.equip.equiprental.equipment.dto.EquipmentItemHistoryDto;
-import com.equip.equiprental.equipment.dto.UpdateItemStatusDto;
-import com.equip.equiprental.equipment.repository.EquipmentItemHistoryRepository;
-import com.equip.equiprental.equipment.repository.EquipmentItemRepository;
-import com.equip.equiprental.member.domain.Member;
-import com.equip.equiprental.rental.domain.Rental;
-import com.equip.equiprental.rental.domain.RentalItem;
-import com.equip.equiprental.rental.repository.RentalItemRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-@ExtendWith(MockitoExtension.class)
-@DisplayName("EquipmentItemServiceImpl 단위 테스트")
-public class EquipmentItemServiceImplTest {
-    @Mock private EquipmentItemRepository equipmentItemRepository;
-    @Mock private EquipmentItemHistoryRepository equipmentItemHistoryRepository;
-    @Mock private RentalItemRepository rentalItemRepository;
-
-    @InjectMocks
-    private EquipmentItemServiceImpl equipmentItemService;
-
-    @Nested
-    @DisplayName("updateItemStatus 메서드 테스트")
-    class updateItemStatus {
-        @Test
-        @DisplayName("성공 - 장비 아이템 상태 변경 및 히스토리 저장")
-        void updateItemStatus_success() {
-            // given
-            Member changer = Member.builder()
-                    .memberId(1L)
-                    .name("Admin")
-                    .build();
-            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
-                    .equipmentItemId(1L)
-                    .newStatus("RENTED")
-                    .build();
-
-            EquipmentItem item = EquipmentItem.builder()
-                    .equipmentItemId(1L)
-                    .status(EquipmentStatus.AVAILABLE)
-                    .build();
-
-            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.of(item));
-
-            // when
-            equipmentItemService.updateItemStatus(dto, changer);
-
-            // then
-            // 상태 변경 검증
-            assertThat(item.getStatus()).isEqualTo(EquipmentStatus.RENTED);
-
-            // 히스토리 저장 검증
-            ArgumentCaptor<EquipmentItemHistory> captor = ArgumentCaptor.forClass(EquipmentItemHistory.class);
-            verify(equipmentItemHistoryRepository).save(captor.capture());
-
-            EquipmentItemHistory savedHistory = captor.getValue();
-            assertThat(savedHistory.getItem()).isEqualTo(item);
-            assertThat(savedHistory.getOldStatus()).isEqualTo(EquipmentStatus.AVAILABLE);
-            assertThat(savedHistory.getNewStatus()).isEqualTo(EquipmentStatus.RENTED);
-            assertThat(savedHistory.getChangedBy()).isEqualTo(changer);
-        }
-
-        @Test
-        @DisplayName("예외 - 장비 아이템 존재하지 않음")
-        void updateItemStatus_itemNotFound() {
-            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
-                    .equipmentItemId(1L)
-                    .newStatus("RENTED")
-                    .build();
-
-            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> equipmentItemService.updateItemStatus(dto, null))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorType")
-                    .isEqualTo(ErrorType.EQUIPMENT_ITEM_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("예외 - 대여 중인 장비 상태 변경 불가")
-        void updateItemStatus_rentedItem() {
-            // given
-            Member changer = Member.builder()
-                    .memberId(1L)
-                    .name("Admin")
-                    .build();
-
-            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
-                    .equipmentItemId(1L)
-                    .newStatus("AVAILABLE") // 변경 시도
-                    .build();
-
-            EquipmentItem item = EquipmentItem.builder()
-                    .equipmentItemId(1L)
-                    .status(EquipmentStatus.RENTED) // 이미 대여 중
-                    .build();
-
-            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.of(item));
-
-            // when & then
-            assertThatThrownBy(() -> equipmentItemService.updateItemStatus(dto, changer))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorType")
-                    .isEqualTo(ErrorType.CANNOT_MODIFY_WHILE_RENTED);
-        }
-    }
-
-    @Nested
-    @DisplayName("getItemHistory 메서드 테스트")
-    class getItemHistory {
-        @Test
-        @DisplayName("성공 - 장비 아이템 히스토리 조회")
-        void getItemHistory_success() {
-            // given
-            Long equipmentItemId = 1L;
-            SearchParamDto paramDto = SearchParamDto.builder()
-                    .page(1)
-                    .size(10)
-                    .build();
-            Pageable pageable = paramDto.getPageable();
-
-            EquipmentItemHistoryDto history1 = EquipmentItemHistoryDto.builder()
-                    .oldStatus("AVAILABLE")
-                    .newStatus("RENTED")
-                    .changedBy("Admin")
-                    .build();
-
-            EquipmentItemHistoryDto history2 = EquipmentItemHistoryDto.builder()
-                    .oldStatus("AVAILABLE")
-                    .newStatus("RENTED")
-                    .changedBy("Admin")
-                    .build();
-
-            // Page 생성
-            Page<EquipmentItemHistoryDto> mockPage = new PageImpl<>(List.of(history1, history2), pageable, 2);
-
-            when(equipmentItemHistoryRepository.findHistoriesByEquipmentItemId(equipmentItemId, pageable))
-                    .thenReturn(mockPage);
-
-            // RENTED 상태일 때 rentalItem 조회 모킹
-            RentalItem mockRentalItem = RentalItem.builder()
-                    .rental(Rental.builder()
-                            .member(Member.builder()
-                                    .name("홍길동")
-                                    .department("개발팀")
-                                    .build())
-                            .build())
-                    .build();
-
-            when(rentalItemRepository.findFirstByEquipmentItem_EquipmentItemIdAndActualReturnDateIsNull(equipmentItemId))
-                    .thenReturn(mockRentalItem);
-
-            // when
-            PageResponseDto<EquipmentItemHistoryDto> response = equipmentItemService.getItemHistory(equipmentItemId, paramDto);
-
-            // then
-            assertThat(response.getContent()).hasSize(2);
-            assertThat(response.getContent().get(0).getCurrentOwnerName()).isEqualTo("홍길동");
-            assertThat(response.getContent().get(0).getCurrentOwnerDept()).isEqualTo("개발팀");
-
-            assertThat(response.getContent().get(1).getCurrentOwnerName()).isEqualTo("홍길동");
-            assertThat(response.getContent().get(1).getCurrentOwnerDept()).isEqualTo("개발팀");
-
-            assertThat(response.getTotalElements()).isEqualTo(2);
-            assertThat(response.isEmpty()).isFalse();
-        }
-
-
-        @Test
-        @DisplayName("성공 - 히스토리 없음 (빈 페이지)")
-        void getItemHistory_empty() {
-            // given
-            Long equipmentItemId = 1L;
-            SearchParamDto paramDto = SearchParamDto.builder()
-                    .page(1)
-                    .size(10)
-                    .build();
-            Pageable pageable = paramDto.getPageable();
-
-            // 빈 페이지 생성
-            Page<EquipmentItemHistoryDto> emptyPage = Page.empty(pageable);
-
-            when(equipmentItemHistoryRepository.findHistoriesByEquipmentItemId(equipmentItemId, pageable))
-                    .thenReturn(emptyPage);
-
-            // when
-            PageResponseDto<EquipmentItemHistoryDto> result = equipmentItemService.getItemHistory(equipmentItemId, paramDto);
-
-            // then
-            assertThat(result.getContent()).isEmpty(); // content는 빈 리스트여야 함
-            assertThat(result.getPage()).isEqualTo(pageable.getPageNumber() + 1);
-            assertThat(result.getSize()).isEqualTo(pageable.getPageSize());
-            assertThat(result.getTotalElements()).isEqualTo(0);
-            assertThat(result.getTotalPages()).isEqualTo(0);
-            assertThat(result.getNumberOfElements()).isEqualTo(0);
-            assertThat(result.isFirst()).isTrue();
-            assertThat(result.isLast()).isTrue();
-            assertThat(result.isEmpty()).isTrue();
-        }
-    }
-}
+//package com.equip.equiprental.equipment.service;
+//
+//import com.equip.equiprental.common.dto.PageResponseDto;
+//import com.equip.equiprental.common.dto.SearchParamDto;
+//import com.equip.equiprental.common.exception.CustomException;
+//import com.equip.equiprental.common.exception.ErrorType;
+//import com.equip.equiprental.equipment.domain.EquipmentItem;
+//import com.equip.equiprental.equipment.domain.EquipmentItemHistory;
+//import com.equip.equiprental.equipment.domain.EquipmentStatus;
+//import com.equip.equiprental.equipment.dto.EquipmentItemHistoryDto;
+//import com.equip.equiprental.equipment.dto.UpdateItemStatusDto;
+//import com.equip.equiprental.equipment.repository.EquipmentItemHistoryRepository;
+//import com.equip.equiprental.equipment.repository.EquipmentItemRepository;
+//import com.equip.equiprental.member.domain.Member;
+//import com.equip.equiprental.rental.domain.Rental;
+//import com.equip.equiprental.rental.domain.RentalItem;
+//import com.equip.equiprental.rental.repository.RentalItemRepository;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Nested;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.PageImpl;
+//import org.springframework.data.domain.Pageable;
+//
+//import java.util.List;
+//import java.util.Optional;
+//
+//import static org.assertj.core.api.Assertions.*;
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//
+//@ExtendWith(MockitoExtension.class)
+//@DisplayName("EquipmentItemServiceImpl 단위 테스트")
+//public class EquipmentItemServiceImplTest {
+//    @Mock private EquipmentItemRepository equipmentItemRepository;
+//    @Mock private EquipmentItemHistoryRepository equipmentItemHistoryRepository;
+//    @Mock private RentalItemRepository rentalItemRepository;
+//
+//    @InjectMocks
+//    private EquipmentItemServiceImpl equipmentItemService;
+//
+//    @Nested
+//    @DisplayName("updateItemStatus 메서드 테스트")
+//    class updateItemStatus {
+//        @Test
+//        @DisplayName("성공 - 장비 아이템 상태 변경 및 히스토리 저장")
+//        void updateItemStatus_success() {
+//            // given
+//            Member changer = Member.builder()
+//                    .memberId(1L)
+//                    .name("Admin")
+//                    .build();
+//            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
+//                    .equipmentItemId(1L)
+//                    .newStatus("RENTED")
+//                    .build();
+//
+//            EquipmentItem item = EquipmentItem.builder()
+//                    .equipmentItemId(1L)
+//                    .status(EquipmentStatus.AVAILABLE)
+//                    .build();
+//
+//            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.of(item));
+//
+//            // when
+//            equipmentItemService.updateItemStatus(dto, changer);
+//
+//            // then
+//            // 상태 변경 검증
+//            assertThat(item.getStatus()).isEqualTo(EquipmentStatus.RENTED);
+//
+//            // 히스토리 저장 검증
+//            ArgumentCaptor<EquipmentItemHistory> captor = ArgumentCaptor.forClass(EquipmentItemHistory.class);
+//            verify(equipmentItemHistoryRepository).save(captor.capture());
+//
+//            EquipmentItemHistory savedHistory = captor.getValue();
+//            assertThat(savedHistory.getItem()).isEqualTo(item);
+//            assertThat(savedHistory.getOldStatus()).isEqualTo(EquipmentStatus.AVAILABLE);
+//            assertThat(savedHistory.getNewStatus()).isEqualTo(EquipmentStatus.RENTED);
+//            assertThat(savedHistory.getChangedBy()).isEqualTo(changer);
+//        }
+//
+//        @Test
+//        @DisplayName("예외 - 장비 아이템 존재하지 않음")
+//        void updateItemStatus_itemNotFound() {
+//            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
+//                    .equipmentItemId(1L)
+//                    .newStatus("RENTED")
+//                    .build();
+//
+//            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.empty());
+//
+//            assertThatThrownBy(() -> equipmentItemService.updateItemStatus(dto, null))
+//                    .isInstanceOf(CustomException.class)
+//                    .extracting("errorType")
+//                    .isEqualTo(ErrorType.EQUIPMENT_ITEM_NOT_FOUND);
+//        }
+//
+//        @Test
+//        @DisplayName("예외 - 대여 중인 장비 상태 변경 불가")
+//        void updateItemStatus_rentedItem() {
+//            // given
+//            Member changer = Member.builder()
+//                    .memberId(1L)
+//                    .name("Admin")
+//                    .build();
+//
+//            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
+//                    .equipmentItemId(1L)
+//                    .newStatus("AVAILABLE") // 변경 시도
+//                    .build();
+//
+//            EquipmentItem item = EquipmentItem.builder()
+//                    .equipmentItemId(1L)
+//                    .status(EquipmentStatus.RENTED) // 이미 대여 중
+//                    .build();
+//
+//            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.of(item));
+//
+//            // when & then
+//            assertThatThrownBy(() -> equipmentItemService.updateItemStatus(dto, changer))
+//                    .isInstanceOf(CustomException.class)
+//                    .extracting("errorType")
+//                    .isEqualTo(ErrorType.CANNOT_MODIFY_WHILE_RENTED);
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("getItemHistory 메서드 테스트")
+//    class getItemHistory {
+//        @Test
+//        @DisplayName("성공 - 장비 아이템 히스토리 조회")
+//        void getItemHistory_success() {
+//            // given
+//            Long equipmentItemId = 1L;
+//            SearchParamDto paramDto = SearchParamDto.builder()
+//                    .page(1)
+//                    .size(10)
+//                    .build();
+//            Pageable pageable = paramDto.getPageable();
+//
+//            EquipmentItemHistoryDto history1 = EquipmentItemHistoryDto.builder()
+//                    .oldStatus("AVAILABLE")
+//                    .newStatus("RENTED")
+//                    .changedBy("Admin")
+//                    .build();
+//
+//            EquipmentItemHistoryDto history2 = EquipmentItemHistoryDto.builder()
+//                    .oldStatus("AVAILABLE")
+//                    .newStatus("RENTED")
+//                    .changedBy("Admin")
+//                    .build();
+//
+//            // Page 생성
+//            Page<EquipmentItemHistoryDto> mockPage = new PageImpl<>(List.of(history1, history2), pageable, 2);
+//
+//            when(equipmentItemHistoryRepository.findHistoriesByEquipmentItemId(equipmentItemId, pageable))
+//                    .thenReturn(mockPage);
+//
+//            // RENTED 상태일 때 rentalItem 조회 모킹
+//            RentalItem mockRentalItem = RentalItem.builder()
+//                    .rental(Rental.builder()
+//                            .member(Member.builder()
+//                                    .name("홍길동")
+//                                    .department("개발팀")
+//                                    .build())
+//                            .build())
+//                    .build();
+//
+//            when(rentalItemRepository.findFirstByEquipmentItem_EquipmentItemIdAndActualReturnDateIsNull(equipmentItemId))
+//                    .thenReturn(mockRentalItem);
+//
+//            // when
+//            PageResponseDto<EquipmentItemHistoryDto> response = equipmentItemService.getItemHistory(equipmentItemId, paramDto);
+//
+//            // then
+//            assertThat(response.getContent()).hasSize(2);
+//            assertThat(response.getContent().get(0).getCurrentOwnerName()).isEqualTo("홍길동");
+//            assertThat(response.getContent().get(0).getCurrentOwnerDept()).isEqualTo("개발팀");
+//
+//            assertThat(response.getContent().get(1).getCurrentOwnerName()).isEqualTo("홍길동");
+//            assertThat(response.getContent().get(1).getCurrentOwnerDept()).isEqualTo("개발팀");
+//
+//            assertThat(response.getTotalElements()).isEqualTo(2);
+//            assertThat(response.isEmpty()).isFalse();
+//        }
+//
+//
+//        @Test
+//        @DisplayName("성공 - 히스토리 없음 (빈 페이지)")
+//        void getItemHistory_empty() {
+//            // given
+//            Long equipmentItemId = 1L;
+//            SearchParamDto paramDto = SearchParamDto.builder()
+//                    .page(1)
+//                    .size(10)
+//                    .build();
+//            Pageable pageable = paramDto.getPageable();
+//
+//            // 빈 페이지 생성
+//            Page<EquipmentItemHistoryDto> emptyPage = Page.empty(pageable);
+//
+//            when(equipmentItemHistoryRepository.findHistoriesByEquipmentItemId(equipmentItemId, pageable))
+//                    .thenReturn(emptyPage);
+//
+//            // when
+//            PageResponseDto<EquipmentItemHistoryDto> result = equipmentItemService.getItemHistory(equipmentItemId, paramDto);
+//
+//            // then
+//            assertThat(result.getContent()).isEmpty(); // content는 빈 리스트여야 함
+//            assertThat(result.getPage()).isEqualTo(pageable.getPageNumber() + 1);
+//            assertThat(result.getSize()).isEqualTo(pageable.getPageSize());
+//            assertThat(result.getTotalElements()).isEqualTo(0);
+//            assertThat(result.getTotalPages()).isEqualTo(0);
+//            assertThat(result.getNumberOfElements()).isEqualTo(0);
+//            assertThat(result.isFirst()).isTrue();
+//            assertThat(result.isLast()).isTrue();
+//            assertThat(result.isEmpty()).isTrue();
+//        }
+//    }
+//}

--- a/src/test/java/com/equip/equiprental/equipment/service/EquipmentItemServiceImplTest.java
+++ b/src/test/java/com/equip/equiprental/equipment/service/EquipmentItemServiceImplTest.java
@@ -1,227 +1,232 @@
-//package com.equip.equiprental.equipment.service;
-//
-//import com.equip.equiprental.common.dto.PageResponseDto;
-//import com.equip.equiprental.common.dto.SearchParamDto;
-//import com.equip.equiprental.common.exception.CustomException;
-//import com.equip.equiprental.common.exception.ErrorType;
-//import com.equip.equiprental.equipment.domain.EquipmentItem;
-//import com.equip.equiprental.equipment.domain.EquipmentItemHistory;
-//import com.equip.equiprental.equipment.domain.EquipmentStatus;
-//import com.equip.equiprental.equipment.dto.EquipmentItemHistoryDto;
-//import com.equip.equiprental.equipment.dto.UpdateItemStatusDto;
-//import com.equip.equiprental.equipment.repository.EquipmentItemHistoryRepository;
-//import com.equip.equiprental.equipment.repository.EquipmentItemRepository;
-//import com.equip.equiprental.member.domain.Member;
-//import com.equip.equiprental.rental.domain.Rental;
-//import com.equip.equiprental.rental.domain.RentalItem;
-//import com.equip.equiprental.rental.repository.RentalItemRepository;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.domain.Page;
-//import org.springframework.data.domain.PageImpl;
-//import org.springframework.data.domain.Pageable;
-//
-//import java.util.List;
-//import java.util.Optional;
-//
-//import static org.assertj.core.api.Assertions.*;
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//@ExtendWith(MockitoExtension.class)
-//@DisplayName("EquipmentItemServiceImpl 단위 테스트")
-//public class EquipmentItemServiceImplTest {
-//    @Mock private EquipmentItemRepository equipmentItemRepository;
-//    @Mock private EquipmentItemHistoryRepository equipmentItemHistoryRepository;
-//    @Mock private RentalItemRepository rentalItemRepository;
-//
-//    @InjectMocks
-//    private EquipmentItemServiceImpl equipmentItemService;
-//
-//    @Nested
-//    @DisplayName("updateItemStatus 메서드 테스트")
-//    class updateItemStatus {
-//        @Test
-//        @DisplayName("성공 - 장비 아이템 상태 변경 및 히스토리 저장")
-//        void updateItemStatus_success() {
-//            // given
-//            Member changer = Member.builder()
-//                    .memberId(1L)
-//                    .name("Admin")
-//                    .build();
-//            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
-//                    .equipmentItemId(1L)
-//                    .newStatus("RENTED")
-//                    .build();
-//
-//            EquipmentItem item = EquipmentItem.builder()
-//                    .equipmentItemId(1L)
-//                    .status(EquipmentStatus.AVAILABLE)
-//                    .build();
-//
-//            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.of(item));
-//
-//            // when
-//            equipmentItemService.updateItemStatus(dto, changer);
-//
-//            // then
-//            // 상태 변경 검증
-//            assertThat(item.getStatus()).isEqualTo(EquipmentStatus.RENTED);
-//
-//            // 히스토리 저장 검증
-//            ArgumentCaptor<EquipmentItemHistory> captor = ArgumentCaptor.forClass(EquipmentItemHistory.class);
-//            verify(equipmentItemHistoryRepository).save(captor.capture());
-//
-//            EquipmentItemHistory savedHistory = captor.getValue();
-//            assertThat(savedHistory.getItem()).isEqualTo(item);
-//            assertThat(savedHistory.getOldStatus()).isEqualTo(EquipmentStatus.AVAILABLE);
-//            assertThat(savedHistory.getNewStatus()).isEqualTo(EquipmentStatus.RENTED);
-//            assertThat(savedHistory.getChangedBy()).isEqualTo(changer);
-//        }
-//
-//        @Test
-//        @DisplayName("예외 - 장비 아이템 존재하지 않음")
-//        void updateItemStatus_itemNotFound() {
-//            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
-//                    .equipmentItemId(1L)
-//                    .newStatus("RENTED")
-//                    .build();
-//
-//            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.empty());
-//
-//            assertThatThrownBy(() -> equipmentItemService.updateItemStatus(dto, null))
-//                    .isInstanceOf(CustomException.class)
-//                    .extracting("errorType")
-//                    .isEqualTo(ErrorType.EQUIPMENT_ITEM_NOT_FOUND);
-//        }
-//
-//        @Test
-//        @DisplayName("예외 - 대여 중인 장비 상태 변경 불가")
-//        void updateItemStatus_rentedItem() {
-//            // given
-//            Member changer = Member.builder()
-//                    .memberId(1L)
-//                    .name("Admin")
-//                    .build();
-//
-//            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
-//                    .equipmentItemId(1L)
-//                    .newStatus("AVAILABLE") // 변경 시도
-//                    .build();
-//
-//            EquipmentItem item = EquipmentItem.builder()
-//                    .equipmentItemId(1L)
-//                    .status(EquipmentStatus.RENTED) // 이미 대여 중
-//                    .build();
-//
-//            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.of(item));
-//
-//            // when & then
-//            assertThatThrownBy(() -> equipmentItemService.updateItemStatus(dto, changer))
-//                    .isInstanceOf(CustomException.class)
-//                    .extracting("errorType")
-//                    .isEqualTo(ErrorType.CANNOT_MODIFY_WHILE_RENTED);
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("getItemHistory 메서드 테스트")
-//    class getItemHistory {
-//        @Test
-//        @DisplayName("성공 - 장비 아이템 히스토리 조회")
-//        void getItemHistory_success() {
-//            // given
-//            Long equipmentItemId = 1L;
-//            SearchParamDto paramDto = SearchParamDto.builder()
-//                    .page(1)
-//                    .size(10)
-//                    .build();
-//            Pageable pageable = paramDto.getPageable();
-//
-//            EquipmentItemHistoryDto history1 = EquipmentItemHistoryDto.builder()
-//                    .oldStatus("AVAILABLE")
-//                    .newStatus("RENTED")
-//                    .changedBy("Admin")
-//                    .build();
-//
-//            EquipmentItemHistoryDto history2 = EquipmentItemHistoryDto.builder()
-//                    .oldStatus("AVAILABLE")
-//                    .newStatus("RENTED")
-//                    .changedBy("Admin")
-//                    .build();
-//
-//            // Page 생성
-//            Page<EquipmentItemHistoryDto> mockPage = new PageImpl<>(List.of(history1, history2), pageable, 2);
-//
-//            when(equipmentItemHistoryRepository.findHistoriesByEquipmentItemId(equipmentItemId, pageable))
-//                    .thenReturn(mockPage);
-//
-//            // RENTED 상태일 때 rentalItem 조회 모킹
-//            RentalItem mockRentalItem = RentalItem.builder()
-//                    .rental(Rental.builder()
-//                            .member(Member.builder()
-//                                    .name("홍길동")
-//                                    .department("개발팀")
-//                                    .build())
-//                            .build())
-//                    .build();
-//
-//            when(rentalItemRepository.findFirstByEquipmentItem_EquipmentItemIdAndActualReturnDateIsNull(equipmentItemId))
-//                    .thenReturn(mockRentalItem);
-//
-//            // when
-//            PageResponseDto<EquipmentItemHistoryDto> response = equipmentItemService.getItemHistory(equipmentItemId, paramDto);
-//
-//            // then
-//            assertThat(response.getContent()).hasSize(2);
-//            assertThat(response.getContent().get(0).getCurrentOwnerName()).isEqualTo("홍길동");
-//            assertThat(response.getContent().get(0).getCurrentOwnerDept()).isEqualTo("개발팀");
-//
-//            assertThat(response.getContent().get(1).getCurrentOwnerName()).isEqualTo("홍길동");
-//            assertThat(response.getContent().get(1).getCurrentOwnerDept()).isEqualTo("개발팀");
-//
-//            assertThat(response.getTotalElements()).isEqualTo(2);
-//            assertThat(response.isEmpty()).isFalse();
-//        }
-//
-//
-//        @Test
-//        @DisplayName("성공 - 히스토리 없음 (빈 페이지)")
-//        void getItemHistory_empty() {
-//            // given
-//            Long equipmentItemId = 1L;
-//            SearchParamDto paramDto = SearchParamDto.builder()
-//                    .page(1)
-//                    .size(10)
-//                    .build();
-//            Pageable pageable = paramDto.getPageable();
-//
-//            // 빈 페이지 생성
-//            Page<EquipmentItemHistoryDto> emptyPage = Page.empty(pageable);
-//
-//            when(equipmentItemHistoryRepository.findHistoriesByEquipmentItemId(equipmentItemId, pageable))
-//                    .thenReturn(emptyPage);
-//
-//            // when
-//            PageResponseDto<EquipmentItemHistoryDto> result = equipmentItemService.getItemHistory(equipmentItemId, paramDto);
-//
-//            // then
-//            assertThat(result.getContent()).isEmpty(); // content는 빈 리스트여야 함
-//            assertThat(result.getPage()).isEqualTo(pageable.getPageNumber() + 1);
-//            assertThat(result.getSize()).isEqualTo(pageable.getPageSize());
-//            assertThat(result.getTotalElements()).isEqualTo(0);
-//            assertThat(result.getTotalPages()).isEqualTo(0);
-//            assertThat(result.getNumberOfElements()).isEqualTo(0);
-//            assertThat(result.isFirst()).isTrue();
-//            assertThat(result.isLast()).isTrue();
-//            assertThat(result.isEmpty()).isTrue();
-//        }
-//    }
-//}
+package com.equip.equiprental.equipment.service;
+
+import com.equip.equiprental.common.dto.PageResponseDto;
+import com.equip.equiprental.common.dto.SearchParamDto;
+import com.equip.equiprental.common.exception.CustomException;
+import com.equip.equiprental.common.exception.ErrorType;
+import com.equip.equiprental.equipment.domain.EquipmentItem;
+import com.equip.equiprental.equipment.domain.EquipmentItemHistory;
+import com.equip.equiprental.equipment.domain.EquipmentStatus;
+import com.equip.equiprental.equipment.dto.EquipmentItemHistoryDto;
+import com.equip.equiprental.equipment.dto.UpdateItemStatusDto;
+import com.equip.equiprental.equipment.repository.EquipmentItemHistoryRepository;
+import com.equip.equiprental.equipment.repository.EquipmentItemRepository;
+import com.equip.equiprental.member.domain.Member;
+import com.equip.equiprental.rental.domain.Rental;
+import com.equip.equiprental.rental.domain.RentalItem;
+import com.equip.equiprental.rental.repository.RentalItemRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EquipmentItemServiceImpl 단위 테스트")
+public class EquipmentItemServiceImplTest {
+    @Mock private EquipmentItemRepository equipmentItemRepository;
+    @Mock private EquipmentItemHistoryRepository equipmentItemHistoryRepository;
+    @Mock private RentalItemRepository rentalItemRepository;
+
+    @InjectMocks
+    private EquipmentItemServiceImpl equipmentItemService;
+
+    @Nested
+    @DisplayName("updateItemStatus 메서드 테스트")
+    class updateItemStatus {
+        @Test
+        @DisplayName("성공 - 장비 아이템 상태 변경 및 히스토리 저장")
+        void updateItemStatus_success() {
+            // given
+            Member changer = Member.builder()
+                    .memberId(1L)
+                    .name("Admin")
+                    .build();
+            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
+                    .equipmentItemId(1L)
+                    .newStatus("RENTED")
+                    .build();
+
+            EquipmentItem item = EquipmentItem.builder()
+                    .equipmentItemId(1L)
+                    .status(EquipmentStatus.AVAILABLE)
+                    .build();
+
+            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.of(item));
+
+            // when
+            equipmentItemService.updateItemStatus(dto, changer);
+
+            // then
+            // 상태 변경 검증
+            assertThat(item.getStatus()).isEqualTo(EquipmentStatus.RENTED);
+
+            // 히스토리 저장 검증
+            ArgumentCaptor<EquipmentItemHistory> captor = ArgumentCaptor.forClass(EquipmentItemHistory.class);
+            verify(equipmentItemHistoryRepository).save(captor.capture());
+
+            EquipmentItemHistory savedHistory = captor.getValue();
+            assertThat(savedHistory.getItem()).isEqualTo(item);
+            assertThat(savedHistory.getOldStatus()).isEqualTo(EquipmentStatus.AVAILABLE);
+            assertThat(savedHistory.getNewStatus()).isEqualTo(EquipmentStatus.RENTED);
+            assertThat(savedHistory.getChangedBy()).isEqualTo(changer);
+        }
+
+        @Test
+        @DisplayName("예외 - 장비 아이템 존재하지 않음")
+        void updateItemStatus_itemNotFound() {
+            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
+                    .equipmentItemId(1L)
+                    .newStatus("RENTED")
+                    .build();
+
+            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> equipmentItemService.updateItemStatus(dto, null))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.EQUIPMENT_ITEM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("예외 - 대여 중인 장비 상태 변경 불가")
+        void updateItemStatus_rentedItem() {
+            // given
+            Member changer = Member.builder()
+                    .memberId(1L)
+                    .name("Admin")
+                    .build();
+
+            UpdateItemStatusDto dto = UpdateItemStatusDto.builder()
+                    .equipmentItemId(1L)
+                    .newStatus("AVAILABLE") // 변경 시도
+                    .build();
+
+            EquipmentItem item = EquipmentItem.builder()
+                    .equipmentItemId(1L)
+                    .status(EquipmentStatus.RENTED) // 이미 대여 중
+                    .build();
+
+            when(equipmentItemRepository.findById(dto.getEquipmentItemId())).thenReturn(Optional.of(item));
+
+            // when & then
+            assertThatThrownBy(() -> equipmentItemService.updateItemStatus(dto, changer))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.CANNOT_MODIFY_WHILE_RENTED);
+        }
+    }
+
+    @Nested
+    @DisplayName("getItemHistory 메서드 테스트")
+    class getItemHistory {
+        private SearchParamDto createParamDto() {
+            return SearchParamDto.builder()
+                    .page(1)
+                    .size(10)
+                    .build();
+        }
+
+        private EquipmentItemHistoryDto createHistory(Long equipmentItemId, String oldStatus, String newStatus, String changedBy) {
+            return EquipmentItemHistoryDto.builder()
+                    .equipmentItemId(equipmentItemId)
+                    .oldStatus(oldStatus)
+                    .newStatus(newStatus)
+                    .changedBy(changedBy)
+                    .rentedUserName("user" + equipmentItemId)
+                    .rentedUserDept("dept" + equipmentItemId)
+                    .rentalStartDate(LocalDate.of(2025, 1, 1))
+                    .actualReturnDate(LocalDate.of(2025, 1, 5))
+                    .createdAt(LocalDateTime.of(2025, 1, 1, 12, 0))
+                    .build();
+        }
+
+        @Test
+        @DisplayName("성공 - 장비 아이템 히스토리 조회 성공")
+        void whenHistoriesExist_thenReturnPagedResult() {
+            // given
+            Long equipmentItemId = 1L;
+            SearchParamDto paramDto = createParamDto();
+            Pageable pageable = paramDto.getPageable();
+
+            EquipmentItemHistoryDto history1 = createHistory(1L, "AVAILABLE", "RENTED", "admin1");
+            EquipmentItemHistoryDto history2 = createHistory(2L, "RENTED", "RETURNED", "admin2");
+
+            Page<EquipmentItemHistoryDto> mockPage = new PageImpl<>(List.of(history1, history2), pageable, 2);
+            when(equipmentItemHistoryRepository.findHistoriesByEquipmentItemId(equipmentItemId, pageable))
+                    .thenReturn(mockPage);
+
+            // when
+            PageResponseDto<EquipmentItemHistoryDto> result = equipmentItemService.getItemHistory(equipmentItemId, paramDto);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getContent())
+                    .extracting(EquipmentItemHistoryDto::getEquipmentItemId,
+                            EquipmentItemHistoryDto::getOldStatus,
+                            EquipmentItemHistoryDto::getNewStatus,
+                            EquipmentItemHistoryDto::getChangedBy)
+                    .containsExactly(
+                            tuple(1L, "AVAILABLE", "RENTED", "admin1"),
+                            tuple(2L, "RENTED", "RETURNED", "admin2")
+                    );
+
+            assertThat(result.getPage()).isEqualTo(1);
+            assertThat(result.getSize()).isEqualTo(10);
+            assertThat(result.getTotalElements()).isEqualTo(2);
+            assertThat(result.getTotalPages()).isEqualTo(1);
+            assertThat(result.getNumberOfElements()).isEqualTo(2);
+            assertThat(result.isFirst()).isTrue();
+            assertThat(result.isLast()).isTrue();
+            assertThat(result.isEmpty()).isFalse();
+
+            verify(equipmentItemHistoryRepository).findHistoriesByEquipmentItemId(equipmentItemId, pageable);
+        }
+
+        @Test
+        @DisplayName("성공 - 히스토리 없음 (빈 페이지)")
+        void whenNoHistoriesExist_thenReturnEmptyPage() {
+            // given
+            Long equipmentItemId = 1L;
+            SearchParamDto paramDto = createParamDto();
+            Pageable pageable = paramDto.getPageable();
+
+            when(equipmentItemHistoryRepository.findHistoriesByEquipmentItemId(equipmentItemId, pageable))
+                    .thenReturn(Page.empty(pageable));
+
+            // when
+            PageResponseDto<EquipmentItemHistoryDto> result = equipmentItemService.getItemHistory(equipmentItemId, paramDto);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.isEmpty()).isTrue();
+
+            assertThat(result.getPage()).isEqualTo(1);
+            assertThat(result.getSize()).isEqualTo(10);
+            assertThat(result.getTotalElements()).isEqualTo(0);
+            assertThat(result.getTotalPages()).isEqualTo(0);
+            assertThat(result.getNumberOfElements()).isEqualTo(0);
+            assertThat(result.isFirst()).isTrue();
+            assertThat(result.isLast()).isTrue();
+
+            verify(equipmentItemHistoryRepository).findHistoriesByEquipmentItemId(equipmentItemId, pageable);
+        }
+    }
+}

--- a/src/test/java/com/equip/equiprental/equipment/service/EquipmentServiceImplTest.java
+++ b/src/test/java/com/equip/equiprental/equipment/service/EquipmentServiceImplTest.java
@@ -1,515 +1,514 @@
-package com.equip.equiprental.equipment.service;
-
-import com.equip.equiprental.common.dto.PageResponseDto;
-import com.equip.equiprental.common.dto.SearchParamDto;
-import com.equip.equiprental.common.exception.CustomException;
-import com.equip.equiprental.common.exception.ErrorType;
-import com.equip.equiprental.equipment.domain.*;
-import com.equip.equiprental.equipment.dto.*;
-import com.equip.equiprental.equipment.repository.EquipmentItemRepository;
-import com.equip.equiprental.equipment.repository.EquipmentRepository;
-import com.equip.equiprental.equipment.util.ModelCodeGenerator;
-import com.equip.equiprental.filestorage.domain.FileMeta;
-import com.equip.equiprental.filestorage.repository.FileRepository;
-import com.equip.equiprental.filestorage.service.FileService;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-@ExtendWith(MockitoExtension.class)
-@DisplayName("EquipmentServiceImpl 단위 테스트")
-public class EquipmentServiceImplTest {
-    @Mock private EquipmentRepository equipmentRepository;
-    @Mock private EquipmentItemRepository equipmentItemRepository;
-    @Mock private ModelCodeGenerator modelCodeGenerator;
-    @Mock private FileRepository fileRepository;
-    @Mock private FileService fileService;
-    
-    @Captor
-    ArgumentCaptor<List<EquipmentItem>> itemListCaptor;
-
-    @Captor
-    ArgumentCaptor<List<FileMeta>> fileMetaListCaptor;
-
-    @InjectMocks
-    private EquipmentServiceImpl equipmentService;
-
-    @Nested
-    @DisplayName("register 메서드 테스트")
-    class register {
-        @Test
-        @DisplayName("성공 - 장비 등록")
-        void register_success() {
-            // given
-            EquipmentRegisterRequest request = EquipmentRegisterRequest.builder()
-                    .category("ELECTRONICS")
-                    .subCategory("monitor")
-                    .model("MODEL_Y")
-                    .stock(1)
-                    .build();
-
-            MultipartFile file = mock(MultipartFile.class);
-            when(file.getOriginalFilename()).thenReturn("test.png");
-            when(file.getContentType()).thenReturn("image/png");
-            when(file.getSize()).thenReturn(123L);
-
-            List<MultipartFile> files = List.of(file);
-            when(equipmentRepository.findByModel("MODEL_Y")).thenReturn(Optional.empty());
-
-            when(equipmentRepository.save(any()))
-                    .thenAnswer(invocation -> {
-                        Equipment eq = invocation.getArgument(0);
-                        Field idField = Equipment.class.getDeclaredField("equipmentId");
-                        idField.setAccessible(true);
-                        idField.set(eq, 1L);
-                        return eq;
-                    });
-
-            when(fileService.saveFiles(files, "equipment"))
-                    .thenReturn(List.of("http://url/to/test.png"));
-
-            // when
-            EquipmentRegisterResponse response = equipmentService.register(request, files);
-
-            // then
-            assertThat(response.getEquipmentId()).isNotNull();
-            assertThat(response.getCategory()).isEqualTo("ELECTRONICS");
-            assertThat(response.getSubCategory()).isEqualTo("monitor");
-            assertThat(response.getModel()).isEqualTo("MODEL_Y");
-            assertThat(response.getStock()).isEqualTo(1);
-
-
-            verify(equipmentItemRepository, times(1)).saveAll(anyList());
-            verify(fileService).saveFiles(files, "equipment");
-            verify(fileRepository).saveAll(anyList());
-        }
-
-        @Test
-        @DisplayName("예외 - 이미 등록된 장비")
-        void register_existingModel_throwsException() {
-            // given
-            EquipmentRegisterRequest request = EquipmentRegisterRequest.builder()
-                    .model("EXIST_MODEL")
-                    .build();
-
-            when(equipmentRepository.findByModel("EXIST_MODEL"))
-                    .thenReturn(Optional.of(new Equipment()));
-
-            // when & then
-            assertThatThrownBy(() -> equipmentService.register(request, null))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorType")
-                    .isEqualTo(ErrorType.EXIST_EQUIPMENT_MODEL_CODE);
-        }
-    }
-
-    @Nested
-    @DisplayName("getEquipment 메서드 테스트")
-    class getEquipment {
-        @Test
-        @DisplayName("성공 - 장비 조회 성공")
-        void getEquipment_success() {
-            // given
-            SearchParamDto paramDto = SearchParamDto.builder()
-                    .page(1)
-                    .size(10)
-                    .category("ELECTRONICS")
-                    .build();
-            Pageable pageable = paramDto.getPageable();
-
-            EquipmentDto equipment1 = EquipmentDto.builder()
-                    .equipmentId(1L)
-                    .category("ELECTRONICS")
-                    .subCategory("Laptop")
-                    .model("LG Gram")
-                    .availableStock(5)
-                    .totalStock(10)
-                    .imageUrl("url1")
-                    .build();
-
-            EquipmentDto equipment2 = EquipmentDto.builder()
-                    .equipmentId(2L)
-                    .category("ELECTRONICS")
-                    .subCategory("Monitor")
-                    .model("삼성 오디세이")
-                    .availableStock(6)
-                    .totalStock(11)
-                    .imageUrl("url2")
-                    .build();
-
-            Page<EquipmentDto> mockPage = new PageImpl<>(List.of(equipment1, equipment2), pageable, 2);
-            when(equipmentRepository.findByFilters(paramDto, pageable)).thenReturn(mockPage);
-
-            // when
-            PageResponseDto<EquipmentDto> result = equipmentService.getEquipment(paramDto);
-
-            // then
-            assertThat(result).isNotNull();
-
-            assertThat(result.getContent()).hasSize(2);
-            assertThat(result.getContent().get(0).getEquipmentId()).isEqualTo(1L);
-            assertThat(result.getContent().get(0).getImageUrl()).isEqualTo("url1");
-            assertThat(result.getContent().get(1).getEquipmentId()).isEqualTo(2L);
-            assertThat(result.getContent().get(1).getImageUrl()).isEqualTo("url2");
-
-            assertThat(result.getPage()).isEqualTo(pageable.getPageNumber() + 1);
-            assertThat(result.getSize()).isEqualTo(pageable.getPageSize());
-            assertThat(result.getTotalElements()).isEqualTo(2);
-            assertThat(result.getTotalPages()).isEqualTo(1);
-            assertThat(result.getNumberOfElements()).isEqualTo(2);
-
-            assertThat(result.isFirst()).isTrue();
-            assertThat(result.isLast()).isTrue();
-            assertThat(result.isEmpty()).isFalse();
-        }
-
-        @Test
-        @DisplayName("성공 - 장비 조회 결과 없음")
-        void getEquipment_empty() {
-            // given
-            SearchParamDto paramDto = SearchParamDto.builder()
-                    .page(1)
-                    .size(10)
-                    .category("ELECTRONICS")
-                    .build();
-            Pageable pageable = paramDto.getPageable();
-
-            Page<EquipmentDto> emptyPage = Page.empty(pageable);
-            when(equipmentRepository.findByFilters(paramDto, pageable)).thenReturn(emptyPage);
-
-            // when
-            PageResponseDto<EquipmentDto> result = equipmentService.getEquipment(paramDto);
-
-            // then
-            assertThat(result).isNotNull();
-
-            assertThat(result.getContent()).isEmpty();
-            assertThat(result.isEmpty()).isTrue();
-
-            assertThat(result.getPage()).isEqualTo(pageable.getPageNumber() + 1);
-            assertThat(result.getSize()).isEqualTo(pageable.getPageSize());
-            assertThat(result.getTotalElements()).isEqualTo(0);
-            assertThat(result.getTotalPages()).isEqualTo(0);
-            assertThat(result.getNumberOfElements()).isEqualTo(0);
-
-            assertThat(result.isFirst()).isTrue();
-            assertThat(result.isLast()).isTrue();
-        }
-    }
-
-    @Nested
-    @DisplayName("getEquipmentItem 메서드 테스트")
-    class getEquipmentItem {
-        @Test
-        @DisplayName("성공 - 장비와 아이템 조회 성공")
-        void getEquipmentItem_success() {
-            // given
-            Long equipmentId = 1L;
-            SearchParamDto paramDto = SearchParamDto.builder()
-                    .page(1)
-                    .size(10)
-                    .equipmentStatus("AVAILABLE")
-                    .build();
-
-            Pageable pageable = paramDto.getPageable();
-
-            Equipment equipment = Equipment.builder()
-                    .equipmentId(equipmentId)
-                    .category(EquipmentCategory.ELECTRONICS)
-                    .subCategory("Laptop")
-                    .model("LG Gram")
-                    .build();
-
-            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
-            when(equipmentItemRepository.countByEquipment_EquipmentIdAndStatus(equipmentId, EquipmentStatus.AVAILABLE))
-                    .thenReturn(5);
-            when(equipmentItemRepository.countByEquipment_EquipmentId(equipmentId))
-                    .thenReturn(10);
-            when(fileRepository.findUrlsByEquipmentId(equipmentId))
-                    .thenReturn(List.of("url1"));
-
-            EquipmentItemDto item1 = EquipmentItemDto.builder().equipmentItemId(1L).status(EquipmentStatus.AVAILABLE).build();
-            EquipmentItemDto item2 = EquipmentItemDto.builder().equipmentItemId(2L).status(EquipmentStatus.AVAILABLE).build();
-            Page<EquipmentItemDto> itemsPage = new PageImpl<>(List.of(item1, item2), pageable, 2);
-
-            when(equipmentItemRepository.findByStatus(equipmentId, EquipmentStatus.AVAILABLE, pageable))
-                    .thenReturn(itemsPage);
-
-            // when
-            EquipmentItemListDto result = equipmentService.getEquipmentItem(equipmentId, paramDto);
-
-            // then
-            // 장비 요약 검증
-            assertThat(result.getEquipmentSummary().getEquipmentId()).isEqualTo(equipmentId);
-            assertThat(result.getEquipmentSummary().getAvailableStock()).isEqualTo(5);
-            assertThat(result.getEquipmentSummary().getTotalStock()).isEqualTo(10);
-            assertThat(result.getEquipmentSummary().getImageUrl()).isEqualTo("url1");
-
-            // 장비 아이템 페이지 검증
-            assertThat(result.getEquipmentItems().getContent()).hasSize(2)
-                    .extracting(EquipmentItemDto::getEquipmentItemId)
-                    .containsExactly(1L, 2L);
-
-            assertThat(result.getEquipmentItems()).extracting(
-                    PageResponseDto::getPage,
-                    PageResponseDto::getSize,
-                    PageResponseDto::getTotalElements,
-                    PageResponseDto::getTotalPages,
-                    PageResponseDto::getNumberOfElements,
-                    PageResponseDto::isFirst,
-                    PageResponseDto::isLast,
-                    PageResponseDto::isEmpty
-            ).containsExactly(1, 10, 2L, 1, 2, true, true, false);
-        }
-
-        @Test
-        @DisplayName("성공 - 장비는 존재하지만 아이템 없음 (빈 페이지)")
-        void getEquipmentItem_emptyItems() {
-            // given
-            Long equipmentId = 1L;
-            SearchParamDto paramDto = SearchParamDto.builder()
-                    .page(1)
-                    .size(10)
-                    .equipmentStatus("AVAILABLE")
-                    .build();
-
-            Pageable pageable = paramDto.getPageable();
-
-            Equipment equipment = Equipment.builder()
-                    .equipmentId(equipmentId)
-                    .category(EquipmentCategory.ELECTRONICS)
-                    .subCategory("Laptop")
-                    .model("LG Gram")
-                    .build();
-
-            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
-            when(equipmentItemRepository.countByEquipment_EquipmentIdAndStatus(equipmentId, EquipmentStatus.AVAILABLE))
-                    .thenReturn(0); // 아이템 없음
-            when(equipmentItemRepository.countByEquipment_EquipmentId(equipmentId))
-                    .thenReturn(0); // 전체 재고도 0
-            when(fileRepository.findUrlsByEquipmentId(equipmentId))
-                    .thenReturn(List.of("url1"));
-
-            Page<EquipmentItemDto> emptyPage = Page.empty(pageable);
-            when(equipmentItemRepository.findByStatus(equipmentId, EquipmentStatus.AVAILABLE, pageable))
-                    .thenReturn(emptyPage);
-
-            // when
-            EquipmentItemListDto result = equipmentService.getEquipmentItem(equipmentId, paramDto);
-
-            // then
-            // 장비 요약 검증
-            assertThat(result.getEquipmentSummary().getEquipmentId()).isEqualTo(equipmentId);
-            assertThat(result.getEquipmentSummary().getAvailableStock()).isEqualTo(0);
-            assertThat(result.getEquipmentSummary().getTotalStock()).isEqualTo(0);
-            assertThat(result.getEquipmentSummary().getImageUrl()).isEqualTo("url1");
-
-            // 장비 아이템 페이지 검증 (빈 페이지)
-            assertThat(result.getEquipmentItems().getContent()).isEmpty();
-            assertThat(result.getEquipmentItems().isEmpty()).isTrue();
-
-            assertThat(result.getEquipmentItems()).extracting(
-                    PageResponseDto::getPage,
-                    PageResponseDto::getSize,
-                    PageResponseDto::getTotalElements,
-                    PageResponseDto::getTotalPages,
-                    PageResponseDto::getNumberOfElements,
-                    PageResponseDto::isFirst,
-                    PageResponseDto::isLast
-            ).containsExactly(1, 10, 0L, 0, 0, true, true);
-        }
-
-        @Test
-        @DisplayName("예외 - 장비가 존재하지 않음")
-        void getEquipmentItem_notFound() {
-            Long equipmentId = 1L;
-            SearchParamDto paramDto = SearchParamDto.builder().build();
-
-            // Mock: 장비가 존재하지 않음
-            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.empty());
-
-            // 검증: CustomException 발생
-            assertThatThrownBy(() -> equipmentService.getEquipmentItem(equipmentId, paramDto))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorType")
-                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
-        }
-    }
-
-    @Nested
-    @DisplayName("increaseStock 메서드 테스트")
-    class increaseStock {
-        @Test
-        @DisplayName("성공 - 재고 증가 및 아이템 추가")
-        void increaseStock_success() {
-            // given
-            Long equipmentId = 1L;
-            IncreaseStockRequestDto dto = IncreaseStockRequestDto.builder()
-                    .amount(3)
-                    .build();
-
-            Equipment equipment = Equipment.builder()
-                    .equipmentId(equipmentId)
-                    .model("LG Gram")
-                    .modelCode("LG001")
-                    .stock(5) // 기존 재고
-                    .build();
-
-            when(equipmentRepository.findByEquipmentId(equipmentId)).thenReturn(Optional.of(equipment));
-            when(equipmentItemRepository.findMaxSequenceByModel(equipment.getModel())).thenReturn(Optional.of(10L));
-
-            // when
-            equipmentService.increaseStock(equipmentId, dto);
-
-            // then
-            // saveAll 호출 검증
-            verify(equipmentItemRepository).saveAll(itemListCaptor.capture());
-
-            List<EquipmentItem> savedItems = itemListCaptor.getValue();
-            assertThat(savedItems).hasSize(3);
-
-            // 시퀀스와 serialNumber 검증
-            assertThat(savedItems.get(0).getSequence()).isEqualTo(11L);
-            assertThat(savedItems.get(1).getSequence()).isEqualTo(12L);
-            assertThat(savedItems.get(2).getSequence()).isEqualTo(13L);
-
-            assertThat(savedItems.get(0).getSerialNumber()).startsWith("LG001");
-            assertThat(savedItems.get(1).getSerialNumber()).startsWith("LG001");
-            assertThat(savedItems.get(2).getSerialNumber()).startsWith("LG001");
-
-            // 상태 검증
-            assertThat(savedItems).allMatch(item -> item.getStatus() == EquipmentStatus.AVAILABLE);
-
-            // Equipment 재고 증가 검증
-            assertThat(equipment.getStock()).isEqualTo(8); // 기존 5 + 3
-        }
-
-        @Test
-        @DisplayName("예외 - 장비가 존재하지 않음")
-        void increaseStock_equipmentNotFound() {
-            Long equipmentId = 1L;
-            IncreaseStockRequestDto dto = IncreaseStockRequestDto.builder()
-                    .amount(3)
-                    .build();
-
-            when(equipmentRepository.findByEquipmentId(equipmentId)).thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> equipmentService.increaseStock(equipmentId, dto))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorType")
-                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
-        }
-    }
-
-    @Nested
-    @DisplayName("updateEquipmentImage 메서드 테스트")
-    class updateEquipmentImage {
-        @Test
-        @DisplayName("성공 - 새 이미지 업로드 (기존 이미지 없음)")
-        void updateEquipmentImage_success_newFiles() throws Exception {
-            // given
-            Long equipmentId = 1L;
-            Equipment equipment = Equipment.builder().equipmentId(equipmentId).build();
-            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
-            when(fileRepository.findByRelatedTypeAndRelatedId("equipment", equipmentId))
-                    .thenReturn(Collections.emptyList());
-
-            MultipartFile file1 = mock(MultipartFile.class);
-            when(file1.getOriginalFilename()).thenReturn("file1.jpg");
-            when(file1.getContentType()).thenReturn("image/jpeg");
-            when(file1.getSize()).thenReturn(100L);
-
-            MultipartFile file2 = mock(MultipartFile.class);
-            when(file2.getOriginalFilename()).thenReturn("file2.jpg");
-            when(file2.getContentType()).thenReturn("image/jpeg");
-            when(file2.getSize()).thenReturn(200L);
-
-            List<MultipartFile> files = List.of(file1, file2);
-            List<String> urls = List.of("http://cdn/file1.jpg", "http://cdn/file2.jpg");
-            when(fileService.saveFiles(files, "equipment")).thenReturn(urls);
-
-            // when
-            equipmentService.updateEquipmentImage(equipmentId, files);
-
-            // then
-            verify(fileRepository, never()).deleteAll(anyList());
-            verify(fileService).saveFiles(files, "equipment");
-
-            verify(fileRepository).saveAll(fileMetaListCaptor.capture());
-
-            List<FileMeta> savedFiles = fileMetaListCaptor.getValue();
-            assertThat(savedFiles).hasSize(2);
-            assertThat(savedFiles.get(0).getOriginalName()).isEqualTo("file1.jpg");
-            assertThat(savedFiles.get(0).getFilePath()).isEqualTo("http://cdn/file1.jpg");
-            assertThat(savedFiles.get(1).getOriginalName()).isEqualTo("file2.jpg");
-            assertThat(savedFiles.get(1).getFilePath()).isEqualTo("http://cdn/file2.jpg");
-        }
-
-        @Test
-        @DisplayName("성공 - 기존 이미지 삭제 후 새 이미지 업로드")
-        void updateEquipmentImage_success_existingFiles() throws Exception {
-            // given
-            Long equipmentId = 1L;
-            Equipment equipment = Equipment.builder().equipmentId(equipmentId).build();
-            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
-
-            FileMeta existingFile = mock(FileMeta.class);
-            when(fileRepository.findByRelatedTypeAndRelatedId("equipment", equipmentId))
-                    .thenReturn(List.of(existingFile));
-
-            MultipartFile newFile = mock(MultipartFile.class);
-            when(newFile.getOriginalFilename()).thenReturn("new.jpg");
-            when(newFile.getContentType()).thenReturn("image/jpeg");
-            when(newFile.getSize()).thenReturn(150L);
-
-            List<MultipartFile> files = List.of(newFile);
-            when(fileService.saveFiles(files, "equipment")).thenReturn(List.of("http://cdn/new.jpg"));
-
-            // when
-            equipmentService.updateEquipmentImage(equipmentId, files);
-
-            // then
-            verify(fileRepository).deleteAll(List.of(existingFile));
-            verify(fileService).saveFiles(files, "equipment");
-
-            verify(fileRepository).saveAll(fileMetaListCaptor.capture());
-
-            List<FileMeta> savedFiles = fileMetaListCaptor.getValue();
-            assertThat(savedFiles).hasSize(1);
-            assertThat(savedFiles.get(0).getOriginalName()).isEqualTo("new.jpg");
-            assertThat(savedFiles.get(0).getFilePath()).isEqualTo("http://cdn/new.jpg");
-        }
-
-        @Test
-        @DisplayName("예외 - 장비가 존재하지 않음")
-        void updateEquipmentImage_equipmentNotFound() {
-            // given
-            Long equipmentId = 1L;
-            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> equipmentService.updateEquipmentImage(equipmentId, List.of()))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorType")
-                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
-        }
-    }
-}
+//package com.equip.equiprental.equipment.service;
+//
+//import com.equip.equiprental.common.dto.PageResponseDto;
+//import com.equip.equiprental.common.dto.SearchParamDto;
+//import com.equip.equiprental.common.exception.CustomException;
+//import com.equip.equiprental.common.exception.ErrorType;
+//import com.equip.equiprental.equipment.domain.*;
+//import com.equip.equiprental.equipment.dto.*;
+//import com.equip.equiprental.equipment.repository.EquipmentItemRepository;
+//import com.equip.equiprental.equipment.repository.EquipmentRepository;
+//import com.equip.equiprental.equipment.util.ModelCodeGenerator;
+//import com.equip.equiprental.filestorage.domain.FileMeta;
+//import com.equip.equiprental.filestorage.repository.FileRepository;
+//import com.equip.equiprental.filestorage.service.FileService;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Nested;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.Captor;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.PageImpl;
+//import org.springframework.data.domain.Pageable;
+//import org.springframework.web.multipart.MultipartFile;
+//
+//import java.lang.reflect.Field;
+//import java.util.Collections;
+//import java.util.List;
+//import java.util.Optional;
+//
+//import static org.assertj.core.api.Assertions.*;
+//import static org.mockito.Mockito.*;
+//
+//@ExtendWith(MockitoExtension.class)
+//@DisplayName("EquipmentServiceImpl 단위 테스트")
+//public class EquipmentServiceImplTest {
+//    @Mock private EquipmentRepository equipmentRepository;
+//    @Mock private EquipmentItemRepository equipmentItemRepository;
+//    @Mock private FileRepository fileRepository;
+//    @Mock private FileService fileService;
+//
+//    @Captor
+//    ArgumentCaptor<List<EquipmentItem>> itemListCaptor;
+//
+//    @Captor
+//    ArgumentCaptor<List<FileMeta>> fileMetaListCaptor;
+//
+//    @InjectMocks
+//    private EquipmentServiceImpl equipmentService;
+//
+//    @Nested
+//    @DisplayName("register 메서드 테스트")
+//    class register {
+//        @Test
+//        @DisplayName("성공 - 장비 등록")
+//        void register_success() {
+//            // given
+//            EquipmentRegisterRequest request = EquipmentRegisterRequest.builder()
+//                    .category("ELECTRONICS")
+//                    .subCategory("monitor")
+//                    .model("MODEL_Y")
+//                    .stock(1)
+//                    .build();
+//
+//            MultipartFile file = mock(MultipartFile.class);
+//            when(file.getOriginalFilename()).thenReturn("test.png");
+//            when(file.getContentType()).thenReturn("image/png");
+//            when(file.getSize()).thenReturn(123L);
+//
+//            List<MultipartFile> files = List.of(file);
+//            when(equipmentRepository.findByModel("MODEL_Y")).thenReturn(Optional.empty());
+//
+//            when(equipmentRepository.save(any()))
+//                    .thenAnswer(invocation -> {
+//                        Equipment eq = invocation.getArgument(0);
+//                        Field idField = Equipment.class.getDeclaredField("equipmentId");
+//                        idField.setAccessible(true);
+//                        idField.set(eq, 1L);
+//                        return eq;
+//                    });
+//
+//            when(fileService.saveFiles(files, "equipment"))
+//                    .thenReturn(List.of("http://url/to/test.png"));
+//
+//            // when
+//            EquipmentRegisterResponse response = equipmentService.register(request, files);
+//
+//            // then
+//            assertThat(response.getEquipmentId()).isNotNull();
+//            assertThat(response.getCategory()).isEqualTo("ELECTRONICS");
+//            assertThat(response.getSubCategory()).isEqualTo("monitor");
+//            assertThat(response.getModel()).isEqualTo("MODEL_Y");
+//            assertThat(response.getStock()).isEqualTo(1);
+//
+//
+//            verify(equipmentItemRepository, times(1)).saveAll(anyList());
+//            verify(fileService).saveFiles(files, "equipment");
+//            verify(fileRepository).saveAll(anyList());
+//        }
+//
+//        @Test
+//        @DisplayName("예외 - 이미 등록된 장비")
+//        void register_existingModel_throwsException() {
+//            // given
+//            EquipmentRegisterRequest request = EquipmentRegisterRequest.builder()
+//                    .model("EXIST_MODEL")
+//                    .build();
+//
+//            when(equipmentRepository.findByModel("EXIST_MODEL"))
+//                    .thenReturn(Optional.of(new Equipment()));
+//
+//            // when & then
+//            assertThatThrownBy(() -> equipmentService.register(request, null))
+//                    .isInstanceOf(CustomException.class)
+//                    .extracting("errorType")
+//                    .isEqualTo(ErrorType.EXIST_EQUIPMENT_MODEL_CODE);
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("getEquipment 메서드 테스트")
+//    class getEquipment {
+//        @Test
+//        @DisplayName("성공 - 장비 조회 성공")
+//        void getEquipment_success() {
+//            // given
+//            SearchParamDto paramDto = SearchParamDto.builder()
+//                    .page(1)
+//                    .size(10)
+//                    .category("ELECTRONICS")
+//                    .build();
+//            Pageable pageable = paramDto.getPageable();
+//
+//            EquipmentDto equipment1 = EquipmentDto.builder()
+//                    .equipmentId(1L)
+//                    .category("ELECTRONICS")
+//                    .subCategory("Laptop")
+//                    .model("LG Gram")
+//                    .availableStock(5)
+//                    .totalStock(10)
+//                    .imageUrl("url1")
+//                    .build();
+//
+//            EquipmentDto equipment2 = EquipmentDto.builder()
+//                    .equipmentId(2L)
+//                    .category("ELECTRONICS")
+//                    .subCategory("Monitor")
+//                    .model("삼성 오디세이")
+//                    .availableStock(6)
+//                    .totalStock(11)
+//                    .imageUrl("url2")
+//                    .build();
+//
+//            Page<EquipmentDto> mockPage = new PageImpl<>(List.of(equipment1, equipment2), pageable, 2);
+//            when(equipmentRepository.findByFilters(paramDto, pageable)).thenReturn(mockPage);
+//
+//            // when
+//            PageResponseDto<EquipmentDto> result = equipmentService.getEquipment(paramDto);
+//
+//            // then
+//            assertThat(result).isNotNull();
+//
+//            assertThat(result.getContent()).hasSize(2);
+//            assertThat(result.getContent().get(0).getEquipmentId()).isEqualTo(1L);
+//            assertThat(result.getContent().get(0).getImageUrl()).isEqualTo("url1");
+//            assertThat(result.getContent().get(1).getEquipmentId()).isEqualTo(2L);
+//            assertThat(result.getContent().get(1).getImageUrl()).isEqualTo("url2");
+//
+//            assertThat(result.getPage()).isEqualTo(pageable.getPageNumber() + 1);
+//            assertThat(result.getSize()).isEqualTo(pageable.getPageSize());
+//            assertThat(result.getTotalElements()).isEqualTo(2);
+//            assertThat(result.getTotalPages()).isEqualTo(1);
+//            assertThat(result.getNumberOfElements()).isEqualTo(2);
+//
+//            assertThat(result.isFirst()).isTrue();
+//            assertThat(result.isLast()).isTrue();
+//            assertThat(result.isEmpty()).isFalse();
+//        }
+//
+//        @Test
+//        @DisplayName("성공 - 장비 조회 결과 없음")
+//        void getEquipment_empty() {
+//            // given
+//            SearchParamDto paramDto = SearchParamDto.builder()
+//                    .page(1)
+//                    .size(10)
+//                    .category("ELECTRONICS")
+//                    .build();
+//            Pageable pageable = paramDto.getPageable();
+//
+//            Page<EquipmentDto> emptyPage = Page.empty(pageable);
+//            when(equipmentRepository.findByFilters(paramDto, pageable)).thenReturn(emptyPage);
+//
+//            // when
+//            PageResponseDto<EquipmentDto> result = equipmentService.getEquipment(paramDto);
+//
+//            // then
+//            assertThat(result).isNotNull();
+//
+//            assertThat(result.getContent()).isEmpty();
+//            assertThat(result.isEmpty()).isTrue();
+//
+//            assertThat(result.getPage()).isEqualTo(pageable.getPageNumber() + 1);
+//            assertThat(result.getSize()).isEqualTo(pageable.getPageSize());
+//            assertThat(result.getTotalElements()).isEqualTo(0);
+//            assertThat(result.getTotalPages()).isEqualTo(0);
+//            assertThat(result.getNumberOfElements()).isEqualTo(0);
+//
+//            assertThat(result.isFirst()).isTrue();
+//            assertThat(result.isLast()).isTrue();
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("getEquipmentItem 메서드 테스트")
+//    class getEquipmentItem {
+//        @Test
+//        @DisplayName("성공 - 장비와 아이템 조회 성공")
+//        void getEquipmentItem_success() {
+//            // given
+//            Long equipmentId = 1L;
+//            SearchParamDto paramDto = SearchParamDto.builder()
+//                    .page(1)
+//                    .size(10)
+//                    .equipmentStatus("AVAILABLE")
+//                    .build();
+//
+//            Pageable pageable = paramDto.getPageable();
+//
+//            Equipment equipment = Equipment.builder()
+//                    .equipmentId(equipmentId)
+//                    .category(EquipmentCategory.ELECTRONICS)
+//                    .subCategory("Laptop")
+//                    .model("LG Gram")
+//                    .build();
+//
+//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
+//            when(equipmentItemRepository.countByEquipment_EquipmentIdAndStatus(equipmentId, EquipmentStatus.AVAILABLE))
+//                    .thenReturn(5);
+//            when(equipmentItemRepository.countByEquipment_EquipmentId(equipmentId))
+//                    .thenReturn(10);
+//            when(fileRepository.findUrlsByEquipmentId(equipmentId))
+//                    .thenReturn(List.of("url1"));
+//
+//            EquipmentItemDto item1 = EquipmentItemDto.builder().equipmentItemId(1L).status(EquipmentStatus.AVAILABLE).build();
+//            EquipmentItemDto item2 = EquipmentItemDto.builder().equipmentItemId(2L).status(EquipmentStatus.AVAILABLE).build();
+//            Page<EquipmentItemDto> itemsPage = new PageImpl<>(List.of(item1, item2), pageable, 2);
+//
+//            when(equipmentItemRepository.findByStatus(equipmentId, EquipmentStatus.AVAILABLE, pageable))
+//                    .thenReturn(itemsPage);
+//
+//            // when
+//            EquipmentItemListDto result = equipmentService.getEquipmentItem(equipmentId, paramDto);
+//
+//            // then
+//            // 장비 요약 검증
+//            assertThat(result.getEquipmentSummary().getEquipmentId()).isEqualTo(equipmentId);
+//            assertThat(result.getEquipmentSummary().getAvailableStock()).isEqualTo(5);
+//            assertThat(result.getEquipmentSummary().getTotalStock()).isEqualTo(10);
+//            assertThat(result.getEquipmentSummary().getImageUrl()).isEqualTo("url1");
+//
+//            // 장비 아이템 페이지 검증
+//            assertThat(result.getEquipmentItems().getContent()).hasSize(2)
+//                    .extracting(EquipmentItemDto::getEquipmentItemId)
+//                    .containsExactly(1L, 2L);
+//
+//            assertThat(result.getEquipmentItems()).extracting(
+//                    PageResponseDto::getPage,
+//                    PageResponseDto::getSize,
+//                    PageResponseDto::getTotalElements,
+//                    PageResponseDto::getTotalPages,
+//                    PageResponseDto::getNumberOfElements,
+//                    PageResponseDto::isFirst,
+//                    PageResponseDto::isLast,
+//                    PageResponseDto::isEmpty
+//            ).containsExactly(1, 10, 2L, 1, 2, true, true, false);
+//        }
+//
+//        @Test
+//        @DisplayName("성공 - 장비는 존재하지만 아이템 없음 (빈 페이지)")
+//        void getEquipmentItem_emptyItems() {
+//            // given
+//            Long equipmentId = 1L;
+//            SearchParamDto paramDto = SearchParamDto.builder()
+//                    .page(1)
+//                    .size(10)
+//                    .equipmentStatus("AVAILABLE")
+//                    .build();
+//
+//            Pageable pageable = paramDto.getPageable();
+//
+//            Equipment equipment = Equipment.builder()
+//                    .equipmentId(equipmentId)
+//                    .category(EquipmentCategory.ELECTRONICS)
+//                    .subCategory("Laptop")
+//                    .model("LG Gram")
+//                    .build();
+//
+//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
+//            when(equipmentItemRepository.countByEquipment_EquipmentIdAndStatus(equipmentId, EquipmentStatus.AVAILABLE))
+//                    .thenReturn(0); // 아이템 없음
+//            when(equipmentItemRepository.countByEquipment_EquipmentId(equipmentId))
+//                    .thenReturn(0); // 전체 재고도 0
+//            when(fileRepository.findUrlsByEquipmentId(equipmentId))
+//                    .thenReturn(List.of("url1"));
+//
+//            Page<EquipmentItemDto> emptyPage = Page.empty(pageable);
+//            when(equipmentItemRepository.findByStatus(equipmentId, EquipmentStatus.AVAILABLE, pageable))
+//                    .thenReturn(emptyPage);
+//
+//            // when
+//            EquipmentItemListDto result = equipmentService.getEquipmentItem(equipmentId, paramDto);
+//
+//            // then
+//            // 장비 요약 검증
+//            assertThat(result.getEquipmentSummary().getEquipmentId()).isEqualTo(equipmentId);
+//            assertThat(result.getEquipmentSummary().getAvailableStock()).isEqualTo(0);
+//            assertThat(result.getEquipmentSummary().getTotalStock()).isEqualTo(0);
+//            assertThat(result.getEquipmentSummary().getImageUrl()).isEqualTo("url1");
+//
+//            // 장비 아이템 페이지 검증 (빈 페이지)
+//            assertThat(result.getEquipmentItems().getContent()).isEmpty();
+//            assertThat(result.getEquipmentItems().isEmpty()).isTrue();
+//
+//            assertThat(result.getEquipmentItems()).extracting(
+//                    PageResponseDto::getPage,
+//                    PageResponseDto::getSize,
+//                    PageResponseDto::getTotalElements,
+//                    PageResponseDto::getTotalPages,
+//                    PageResponseDto::getNumberOfElements,
+//                    PageResponseDto::isFirst,
+//                    PageResponseDto::isLast
+//            ).containsExactly(1, 10, 0L, 0, 0, true, true);
+//        }
+//
+//        @Test
+//        @DisplayName("예외 - 장비가 존재하지 않음")
+//        void getEquipmentItem_notFound() {
+//            Long equipmentId = 1L;
+//            SearchParamDto paramDto = SearchParamDto.builder().build();
+//
+//            // Mock: 장비가 존재하지 않음
+//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.empty());
+//
+//            // 검증: CustomException 발생
+//            assertThatThrownBy(() -> equipmentService.getEquipmentItem(equipmentId, paramDto))
+//                    .isInstanceOf(CustomException.class)
+//                    .extracting("errorType")
+//                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("increaseStock 메서드 테스트")
+//    class increaseStock {
+//        @Test
+//        @DisplayName("성공 - 재고 증가 및 아이템 추가")
+//        void increaseStock_success() {
+//            // given
+//            Long equipmentId = 1L;
+//            IncreaseStockRequestDto dto = IncreaseStockRequestDto.builder()
+//                    .amount(3)
+//                    .build();
+//
+//            Equipment equipment = Equipment.builder()
+//                    .equipmentId(equipmentId)
+//                    .model("LG Gram")
+//                    .modelCode("LG001")
+//                    .stock(5) // 기존 재고
+//                    .build();
+//
+//            when(equipmentRepository.findByEquipmentId(equipmentId)).thenReturn(Optional.of(equipment));
+//            when(equipmentItemRepository.findMaxSequenceByModel(equipment.getModel())).thenReturn(Optional.of(10L));
+//
+//            // when
+//            equipmentService.increaseStock(equipmentId, dto);
+//
+//            // then
+//            // saveAll 호출 검증
+//            verify(equipmentItemRepository).saveAll(itemListCaptor.capture());
+//
+//            List<EquipmentItem> savedItems = itemListCaptor.getValue();
+//            assertThat(savedItems).hasSize(3);
+//
+//            // 시퀀스와 serialNumber 검증
+//            assertThat(savedItems.get(0).getSequence()).isEqualTo(11L);
+//            assertThat(savedItems.get(1).getSequence()).isEqualTo(12L);
+//            assertThat(savedItems.get(2).getSequence()).isEqualTo(13L);
+//
+//            assertThat(savedItems.get(0).getSerialNumber()).startsWith("LG001");
+//            assertThat(savedItems.get(1).getSerialNumber()).startsWith("LG001");
+//            assertThat(savedItems.get(2).getSerialNumber()).startsWith("LG001");
+//
+//            // 상태 검증
+//            assertThat(savedItems).allMatch(item -> item.getStatus() == EquipmentStatus.AVAILABLE);
+//
+//            // Equipment 재고 증가 검증
+//            assertThat(equipment.getStock()).isEqualTo(8); // 기존 5 + 3
+//        }
+//
+//        @Test
+//        @DisplayName("예외 - 장비가 존재하지 않음")
+//        void increaseStock_equipmentNotFound() {
+//            Long equipmentId = 1L;
+//            IncreaseStockRequestDto dto = IncreaseStockRequestDto.builder()
+//                    .amount(3)
+//                    .build();
+//
+//            when(equipmentRepository.findByEquipmentId(equipmentId)).thenReturn(Optional.empty());
+//
+//            assertThatThrownBy(() -> equipmentService.increaseStock(equipmentId, dto))
+//                    .isInstanceOf(CustomException.class)
+//                    .extracting("errorType")
+//                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("updateEquipmentImage 메서드 테스트")
+//    class updateEquipmentImage {
+//        @Test
+//        @DisplayName("성공 - 새 이미지 업로드 (기존 이미지 없음)")
+//        void updateEquipmentImage_success_newFiles() throws Exception {
+//            // given
+//            Long equipmentId = 1L;
+//            Equipment equipment = Equipment.builder().equipmentId(equipmentId).build();
+//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
+//            when(fileRepository.findByRelatedTypeAndRelatedId("equipment", equipmentId))
+//                    .thenReturn(Collections.emptyList());
+//
+//            MultipartFile file1 = mock(MultipartFile.class);
+//            when(file1.getOriginalFilename()).thenReturn("file1.jpg");
+//            when(file1.getContentType()).thenReturn("image/jpeg");
+//            when(file1.getSize()).thenReturn(100L);
+//
+//            MultipartFile file2 = mock(MultipartFile.class);
+//            when(file2.getOriginalFilename()).thenReturn("file2.jpg");
+//            when(file2.getContentType()).thenReturn("image/jpeg");
+//            when(file2.getSize()).thenReturn(200L);
+//
+//            List<MultipartFile> files = List.of(file1, file2);
+//            List<String> urls = List.of("http://cdn/file1.jpg", "http://cdn/file2.jpg");
+//            when(fileService.saveFiles(files, "equipment")).thenReturn(urls);
+//
+//            // when
+//            equipmentService.updateEquipmentImage(equipmentId, files);
+//
+//            // then
+//            verify(fileRepository, never()).deleteAll(anyList());
+//            verify(fileService).saveFiles(files, "equipment");
+//
+//            verify(fileRepository).saveAll(fileMetaListCaptor.capture());
+//
+//            List<FileMeta> savedFiles = fileMetaListCaptor.getValue();
+//            assertThat(savedFiles).hasSize(2);
+//            assertThat(savedFiles.get(0).getOriginalName()).isEqualTo("file1.jpg");
+//            assertThat(savedFiles.get(0).getFilePath()).isEqualTo("http://cdn/file1.jpg");
+//            assertThat(savedFiles.get(1).getOriginalName()).isEqualTo("file2.jpg");
+//            assertThat(savedFiles.get(1).getFilePath()).isEqualTo("http://cdn/file2.jpg");
+//        }
+//
+//        @Test
+//        @DisplayName("성공 - 기존 이미지 삭제 후 새 이미지 업로드")
+//        void updateEquipmentImage_success_existingFiles() throws Exception {
+//            // given
+//            Long equipmentId = 1L;
+//            Equipment equipment = Equipment.builder().equipmentId(equipmentId).build();
+//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
+//
+//            FileMeta existingFile = mock(FileMeta.class);
+//            when(fileRepository.findByRelatedTypeAndRelatedId("equipment", equipmentId))
+//                    .thenReturn(List.of(existingFile));
+//
+//            MultipartFile newFile = mock(MultipartFile.class);
+//            when(newFile.getOriginalFilename()).thenReturn("new.jpg");
+//            when(newFile.getContentType()).thenReturn("image/jpeg");
+//            when(newFile.getSize()).thenReturn(150L);
+//
+//            List<MultipartFile> files = List.of(newFile);
+//            when(fileService.saveFiles(files, "equipment")).thenReturn(List.of("http://cdn/new.jpg"));
+//
+//            // when
+//            equipmentService.updateEquipmentImage(equipmentId, files);
+//
+//            // then
+//            verify(fileRepository).deleteAll(List.of(existingFile));
+//            verify(fileService).saveFiles(files, "equipment");
+//
+//            verify(fileRepository).saveAll(fileMetaListCaptor.capture());
+//
+//            List<FileMeta> savedFiles = fileMetaListCaptor.getValue();
+//            assertThat(savedFiles).hasSize(1);
+//            assertThat(savedFiles.get(0).getOriginalName()).isEqualTo("new.jpg");
+//            assertThat(savedFiles.get(0).getFilePath()).isEqualTo("http://cdn/new.jpg");
+//        }
+//
+//        @Test
+//        @DisplayName("예외 - 장비가 존재하지 않음")
+//        void updateEquipmentImage_equipmentNotFound() {
+//            // given
+//            Long equipmentId = 1L;
+//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.empty());
+//
+//            // when & then
+//            assertThatThrownBy(() -> equipmentService.updateEquipmentImage(equipmentId, List.of()))
+//                    .isInstanceOf(CustomException.class)
+//                    .extracting("errorType")
+//                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
+//        }
+//    }
+//}

--- a/src/test/java/com/equip/equiprental/equipment/service/EquipmentServiceImplTest.java
+++ b/src/test/java/com/equip/equiprental/equipment/service/EquipmentServiceImplTest.java
@@ -1,125 +1,177 @@
-//package com.equip.equiprental.equipment.service;
-//
-//import com.equip.equiprental.common.dto.PageResponseDto;
-//import com.equip.equiprental.common.dto.SearchParamDto;
-//import com.equip.equiprental.common.exception.CustomException;
-//import com.equip.equiprental.common.exception.ErrorType;
-//import com.equip.equiprental.equipment.domain.*;
-//import com.equip.equiprental.equipment.dto.*;
-//import com.equip.equiprental.equipment.repository.EquipmentItemRepository;
-//import com.equip.equiprental.equipment.repository.EquipmentRepository;
-//import com.equip.equiprental.equipment.util.ModelCodeGenerator;
-//import com.equip.equiprental.filestorage.domain.FileMeta;
-//import com.equip.equiprental.filestorage.repository.FileRepository;
-//import com.equip.equiprental.filestorage.service.FileService;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.Captor;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.domain.Page;
-//import org.springframework.data.domain.PageImpl;
-//import org.springframework.data.domain.Pageable;
-//import org.springframework.web.multipart.MultipartFile;
-//
-//import java.lang.reflect.Field;
-//import java.util.Collections;
-//import java.util.List;
-//import java.util.Optional;
-//
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//@DisplayName("EquipmentServiceImpl 단위 테스트")
-//public class EquipmentServiceImplTest {
-//    @Mock private EquipmentRepository equipmentRepository;
-//    @Mock private EquipmentItemRepository equipmentItemRepository;
-//    @Mock private FileRepository fileRepository;
-//    @Mock private FileService fileService;
-//
-//    @Captor
-//    ArgumentCaptor<List<EquipmentItem>> itemListCaptor;
-//
-//    @Captor
-//    ArgumentCaptor<List<FileMeta>> fileMetaListCaptor;
-//
-//    @InjectMocks
-//    private EquipmentServiceImpl equipmentService;
-//
-//    @Nested
-//    @DisplayName("register 메서드 테스트")
-//    class register {
-//        @Test
-//        @DisplayName("성공 - 장비 등록")
-//        void register_success() {
-//            // given
-//            EquipmentRegisterRequest request = EquipmentRegisterRequest.builder()
-//                    .category("ELECTRONICS")
-//                    .subCategory("monitor")
-//                    .model("MODEL_Y")
-//                    .stock(1)
-//                    .build();
-//
-//            MultipartFile file = mock(MultipartFile.class);
-//            when(file.getOriginalFilename()).thenReturn("test.png");
-//            when(file.getContentType()).thenReturn("image/png");
-//            when(file.getSize()).thenReturn(123L);
-//
-//            List<MultipartFile> files = List.of(file);
-//            when(equipmentRepository.findByModel("MODEL_Y")).thenReturn(Optional.empty());
-//
-//            when(equipmentRepository.save(any()))
-//                    .thenAnswer(invocation -> {
-//                        Equipment eq = invocation.getArgument(0);
-//                        Field idField = Equipment.class.getDeclaredField("equipmentId");
-//                        idField.setAccessible(true);
-//                        idField.set(eq, 1L);
-//                        return eq;
-//                    });
-//
-//            when(fileService.saveFiles(files, "equipment"))
-//                    .thenReturn(List.of("http://url/to/test.png"));
-//
-//            // when
-//            EquipmentRegisterResponse response = equipmentService.register(request, files);
-//
-//            // then
-//            assertThat(response.getEquipmentId()).isNotNull();
-//            assertThat(response.getCategory()).isEqualTo("ELECTRONICS");
-//            assertThat(response.getSubCategory()).isEqualTo("monitor");
-//            assertThat(response.getModel()).isEqualTo("MODEL_Y");
-//            assertThat(response.getStock()).isEqualTo(1);
-//
-//
-//            verify(equipmentItemRepository, times(1)).saveAll(anyList());
-//            verify(fileService).saveFiles(files, "equipment");
-//            verify(fileRepository).saveAll(anyList());
-//        }
-//
-//        @Test
-//        @DisplayName("예외 - 이미 등록된 장비")
-//        void register_existingModel_throwsException() {
-//            // given
-//            EquipmentRegisterRequest request = EquipmentRegisterRequest.builder()
-//                    .model("EXIST_MODEL")
-//                    .build();
-//
-//            when(equipmentRepository.findByModel("EXIST_MODEL"))
-//                    .thenReturn(Optional.of(new Equipment()));
-//
-//            // when & then
-//            assertThatThrownBy(() -> equipmentService.register(request, null))
-//                    .isInstanceOf(CustomException.class)
-//                    .extracting("errorType")
-//                    .isEqualTo(ErrorType.EXIST_EQUIPMENT_MODEL_CODE);
-//        }
-//    }
-//
+package com.equip.equiprental.equipment.service;
+
+import com.equip.equiprental.common.dto.PageResponseDto;
+import com.equip.equiprental.common.dto.SearchParamDto;
+import com.equip.equiprental.common.exception.CustomException;
+import com.equip.equiprental.common.exception.ErrorType;
+import com.equip.equiprental.equipment.domain.*;
+import com.equip.equiprental.equipment.dto.*;
+import com.equip.equiprental.equipment.repository.EquipmentItemRepository;
+import com.equip.equiprental.equipment.repository.EquipmentRepository;
+import com.equip.equiprental.equipment.repository.SubCategoryRepository;
+import com.equip.equiprental.filestorage.domain.FileMeta;
+import com.equip.equiprental.filestorage.repository.FileRepository;
+import com.equip.equiprental.filestorage.service.FileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EquipmentServiceImpl 단위 테스트")
+public class EquipmentServiceImplTest {
+    @Mock private SubCategoryRepository subCategoryRepository;
+    @Mock private EquipmentRepository equipmentRepository;
+    @Mock private EquipmentItemRepository equipmentItemRepository;
+    @Mock private FileRepository fileRepository;
+    @Mock private FileService fileService;
+
+    @Captor
+    ArgumentCaptor<List<EquipmentItem>> itemListCaptor;
+
+    @Captor
+    ArgumentCaptor<List<FileMeta>> fileMetaListCaptor;
+
+    @InjectMocks
+    private EquipmentServiceImpl equipmentService;
+
+    @Nested
+    @DisplayName("register 메서드 테스트")
+    class register {
+        private SubCategory mockSubCategory;
+
+        @BeforeEach
+        void setUp() {
+            mockSubCategory = SubCategory.builder()
+                    .subCategoryId(1L)
+                    .subCategoryCode("MON")
+                    .label("monitor")
+                    .category(Category.builder()
+                            .categoryCode("EL")
+                            .label("ELECTRONICS")
+                            .build())
+                    .build();
+        }
+
+        // 헬퍼 메서드
+        private void mockEquipmentSave() throws Exception {
+            when(equipmentRepository.save(any()))
+                    .thenAnswer(invocation -> {
+                        Equipment eq = invocation.getArgument(0);
+                        setEquipmentId(eq, 1L);
+                        return eq;
+                    });
+        }
+
+        private void setEquipmentId(Equipment equipment, Long id) throws Exception {
+            Field idField = Equipment.class.getDeclaredField("equipmentId");
+            idField.setAccessible(true);
+            idField.set(equipment, id);
+        }
+
+        private MultipartFile mockFile(String name, String type, long size) {
+            MultipartFile file = mock(MultipartFile.class);
+            when(file.getOriginalFilename()).thenReturn(name);
+            when(file.getContentType()).thenReturn(type);
+            when(file.getSize()).thenReturn(size);
+            return file;
+        }
+
+        @Test
+        @DisplayName("성공 - 장비 등록")
+        void register_success() throws Exception {
+            // given
+            EquipmentRegisterRequest request = EquipmentRegisterRequest.builder()
+                    .subCategoryId(1L)
+                    .model("MODEL_Y")
+                    .stock(1)
+                    .build();
+
+            MultipartFile file = mockFile("test.png", "image/png", 123L);
+            List<MultipartFile> files = List.of(file);
+
+            when(subCategoryRepository.findById(1L))
+                    .thenReturn(Optional.of(mockSubCategory));
+
+            when(equipmentRepository.findByModel("MODEL_Y"))
+                    .thenReturn(Optional.empty());
+
+            mockEquipmentSave();
+
+            when(fileService.saveFiles(files, "equipment"))
+                    .thenReturn(List.of("http://url/to/test.png"));
+
+            // when
+            EquipmentRegisterResponse response = equipmentService.register(request, files);
+
+            // then
+            assertThat(response.getEquipmentId()).isNotNull();
+            assertThat(response.getSubCategory()).isEqualTo(mockSubCategory.getLabel());
+            assertThat(response.getModel()).isEqualTo("MODEL_Y");
+            assertThat(response.getStock()).isEqualTo(1);
+            assertThat(response.getImages()).hasSize(1)
+                    .allMatch(img -> img.getOriginalName().equals("test.png"));
+
+            verify(equipmentItemRepository, times(1)).saveAll(anyList());
+            verify(fileService).saveFiles(files, "equipment");
+            verify(fileRepository).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("예외 - 존재하지 않는 SubCategory")
+        void register_nonExistentSubCategory_throwsException() {
+            EquipmentRegisterRequest request = EquipmentRegisterRequest.builder()
+                    .subCategoryId(999L)
+                    .model("MODEL_X")
+                    .build();
+
+            when(subCategoryRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> equipmentService.register(request, null))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("예외 - 이미 등록된 장비")
+        void register_existingModel_throwsException() {
+            EquipmentRegisterRequest request = EquipmentRegisterRequest.builder()
+                    .subCategoryId(1L)
+                    .model("EXIST_MODEL")
+                    .build();
+
+            when(subCategoryRepository.findById(1L))
+                    .thenReturn(Optional.of(mockSubCategory));
+
+            when(equipmentRepository.findByModel("EXIST_MODEL"))
+                    .thenReturn(Optional.of(new Equipment()));
+
+            assertThatThrownBy(() -> equipmentService.register(request, null))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.EXIST_EQUIPMENT_MODEL_CODE);
+        }
+    }
+
 //    @Nested
 //    @DisplayName("getEquipment 메서드 테스트")
 //    class getEquipment {
@@ -352,163 +404,163 @@
 //                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
 //        }
 //    }
-//
-//    @Nested
-//    @DisplayName("increaseStock 메서드 테스트")
-//    class increaseStock {
-//        @Test
-//        @DisplayName("성공 - 재고 증가 및 아이템 추가")
-//        void increaseStock_success() {
-//            // given
-//            Long equipmentId = 1L;
-//            IncreaseStockRequestDto dto = IncreaseStockRequestDto.builder()
-//                    .amount(3)
-//                    .build();
-//
-//            Equipment equipment = Equipment.builder()
-//                    .equipmentId(equipmentId)
-//                    .model("LG Gram")
-//                    .modelCode("LG001")
-//                    .stock(5) // 기존 재고
-//                    .build();
-//
-//            when(equipmentRepository.findByEquipmentId(equipmentId)).thenReturn(Optional.of(equipment));
-//            when(equipmentItemRepository.findMaxSequenceByModel(equipment.getModel())).thenReturn(Optional.of(10L));
-//
-//            // when
-//            equipmentService.increaseStock(equipmentId, dto);
-//
-//            // then
-//            // saveAll 호출 검증
-//            verify(equipmentItemRepository).saveAll(itemListCaptor.capture());
-//
-//            List<EquipmentItem> savedItems = itemListCaptor.getValue();
-//            assertThat(savedItems).hasSize(3);
-//
-//            // 시퀀스와 serialNumber 검증
-//            assertThat(savedItems.get(0).getSequence()).isEqualTo(11L);
-//            assertThat(savedItems.get(1).getSequence()).isEqualTo(12L);
-//            assertThat(savedItems.get(2).getSequence()).isEqualTo(13L);
-//
-//            assertThat(savedItems.get(0).getSerialNumber()).startsWith("LG001");
-//            assertThat(savedItems.get(1).getSerialNumber()).startsWith("LG001");
-//            assertThat(savedItems.get(2).getSerialNumber()).startsWith("LG001");
-//
-//            // 상태 검증
-//            assertThat(savedItems).allMatch(item -> item.getStatus() == EquipmentStatus.AVAILABLE);
-//
-//            // Equipment 재고 증가 검증
-//            assertThat(equipment.getStock()).isEqualTo(8); // 기존 5 + 3
-//        }
-//
-//        @Test
-//        @DisplayName("예외 - 장비가 존재하지 않음")
-//        void increaseStock_equipmentNotFound() {
-//            Long equipmentId = 1L;
-//            IncreaseStockRequestDto dto = IncreaseStockRequestDto.builder()
-//                    .amount(3)
-//                    .build();
-//
-//            when(equipmentRepository.findByEquipmentId(equipmentId)).thenReturn(Optional.empty());
-//
-//            assertThatThrownBy(() -> equipmentService.increaseStock(equipmentId, dto))
-//                    .isInstanceOf(CustomException.class)
-//                    .extracting("errorType")
-//                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("updateEquipmentImage 메서드 테스트")
-//    class updateEquipmentImage {
-//        @Test
-//        @DisplayName("성공 - 새 이미지 업로드 (기존 이미지 없음)")
-//        void updateEquipmentImage_success_newFiles() throws Exception {
-//            // given
-//            Long equipmentId = 1L;
-//            Equipment equipment = Equipment.builder().equipmentId(equipmentId).build();
-//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
-//            when(fileRepository.findByRelatedTypeAndRelatedId("equipment", equipmentId))
-//                    .thenReturn(Collections.emptyList());
-//
-//            MultipartFile file1 = mock(MultipartFile.class);
-//            when(file1.getOriginalFilename()).thenReturn("file1.jpg");
-//            when(file1.getContentType()).thenReturn("image/jpeg");
-//            when(file1.getSize()).thenReturn(100L);
-//
-//            MultipartFile file2 = mock(MultipartFile.class);
-//            when(file2.getOriginalFilename()).thenReturn("file2.jpg");
-//            when(file2.getContentType()).thenReturn("image/jpeg");
-//            when(file2.getSize()).thenReturn(200L);
-//
-//            List<MultipartFile> files = List.of(file1, file2);
-//            List<String> urls = List.of("http://cdn/file1.jpg", "http://cdn/file2.jpg");
-//            when(fileService.saveFiles(files, "equipment")).thenReturn(urls);
-//
-//            // when
-//            equipmentService.updateEquipmentImage(equipmentId, files);
-//
-//            // then
-//            verify(fileRepository, never()).deleteAll(anyList());
-//            verify(fileService).saveFiles(files, "equipment");
-//
-//            verify(fileRepository).saveAll(fileMetaListCaptor.capture());
-//
-//            List<FileMeta> savedFiles = fileMetaListCaptor.getValue();
-//            assertThat(savedFiles).hasSize(2);
-//            assertThat(savedFiles.get(0).getOriginalName()).isEqualTo("file1.jpg");
-//            assertThat(savedFiles.get(0).getFilePath()).isEqualTo("http://cdn/file1.jpg");
-//            assertThat(savedFiles.get(1).getOriginalName()).isEqualTo("file2.jpg");
-//            assertThat(savedFiles.get(1).getFilePath()).isEqualTo("http://cdn/file2.jpg");
-//        }
-//
-//        @Test
-//        @DisplayName("성공 - 기존 이미지 삭제 후 새 이미지 업로드")
-//        void updateEquipmentImage_success_existingFiles() throws Exception {
-//            // given
-//            Long equipmentId = 1L;
-//            Equipment equipment = Equipment.builder().equipmentId(equipmentId).build();
-//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
-//
-//            FileMeta existingFile = mock(FileMeta.class);
-//            when(fileRepository.findByRelatedTypeAndRelatedId("equipment", equipmentId))
-//                    .thenReturn(List.of(existingFile));
-//
-//            MultipartFile newFile = mock(MultipartFile.class);
-//            when(newFile.getOriginalFilename()).thenReturn("new.jpg");
-//            when(newFile.getContentType()).thenReturn("image/jpeg");
-//            when(newFile.getSize()).thenReturn(150L);
-//
-//            List<MultipartFile> files = List.of(newFile);
-//            when(fileService.saveFiles(files, "equipment")).thenReturn(List.of("http://cdn/new.jpg"));
-//
-//            // when
-//            equipmentService.updateEquipmentImage(equipmentId, files);
-//
-//            // then
-//            verify(fileRepository).deleteAll(List.of(existingFile));
-//            verify(fileService).saveFiles(files, "equipment");
-//
-//            verify(fileRepository).saveAll(fileMetaListCaptor.capture());
-//
-//            List<FileMeta> savedFiles = fileMetaListCaptor.getValue();
-//            assertThat(savedFiles).hasSize(1);
-//            assertThat(savedFiles.get(0).getOriginalName()).isEqualTo("new.jpg");
-//            assertThat(savedFiles.get(0).getFilePath()).isEqualTo("http://cdn/new.jpg");
-//        }
-//
-//        @Test
-//        @DisplayName("예외 - 장비가 존재하지 않음")
-//        void updateEquipmentImage_equipmentNotFound() {
-//            // given
-//            Long equipmentId = 1L;
-//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.empty());
-//
-//            // when & then
-//            assertThatThrownBy(() -> equipmentService.updateEquipmentImage(equipmentId, List.of()))
-//                    .isInstanceOf(CustomException.class)
-//                    .extracting("errorType")
-//                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
-//        }
-//    }
-//}
+
+    @Nested
+    @DisplayName("increaseStock 메서드 테스트")
+    class increaseStock {
+        @Test
+        @DisplayName("성공 - 재고 증가 및 아이템 추가")
+        void increaseStock_success() {
+            // given
+            Long equipmentId = 1L;
+            IncreaseStockRequestDto dto = IncreaseStockRequestDto.builder()
+                    .amount(3)
+                    .build();
+
+            Equipment equipment = Equipment.builder()
+                    .equipmentId(equipmentId)
+                    .model("LG Gram")
+                    .modelCode("LG001")
+                    .stock(5) // 기존 재고
+                    .build();
+
+            when(equipmentRepository.findByEquipmentId(equipmentId)).thenReturn(Optional.of(equipment));
+            when(equipmentItemRepository.findMaxSequenceByModel(equipment.getModel())).thenReturn(Optional.of(10L));
+
+            // when
+            equipmentService.increaseStock(equipmentId, dto);
+
+            // then
+            // saveAll 호출 검증
+            verify(equipmentItemRepository).saveAll(itemListCaptor.capture());
+
+            List<EquipmentItem> savedItems = itemListCaptor.getValue();
+            assertThat(savedItems).hasSize(3);
+
+            // 시퀀스와 serialNumber 검증
+            assertThat(savedItems.get(0).getSequence()).isEqualTo(11L);
+            assertThat(savedItems.get(1).getSequence()).isEqualTo(12L);
+            assertThat(savedItems.get(2).getSequence()).isEqualTo(13L);
+
+            assertThat(savedItems.get(0).getSerialNumber()).startsWith("LG001");
+            assertThat(savedItems.get(1).getSerialNumber()).startsWith("LG001");
+            assertThat(savedItems.get(2).getSerialNumber()).startsWith("LG001");
+
+            // 상태 검증
+            assertThat(savedItems).allMatch(item -> item.getStatus() == EquipmentStatus.AVAILABLE);
+
+            // Equipment 재고 증가 검증
+            assertThat(equipment.getStock()).isEqualTo(8); // 기존 5 + 3
+        }
+
+        @Test
+        @DisplayName("예외 - 장비가 존재하지 않음")
+        void increaseStock_equipmentNotFound() {
+            Long equipmentId = 1L;
+            IncreaseStockRequestDto dto = IncreaseStockRequestDto.builder()
+                    .amount(3)
+                    .build();
+
+            when(equipmentRepository.findByEquipmentId(equipmentId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> equipmentService.increaseStock(equipmentId, dto))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateEquipmentImage 메서드 테스트")
+    class updateEquipmentImage {
+        @Test
+        @DisplayName("성공 - 새 이미지 업로드 (기존 이미지 없음)")
+        void updateEquipmentImage_success_newFiles() throws Exception {
+            // given
+            Long equipmentId = 1L;
+            Equipment equipment = Equipment.builder().equipmentId(equipmentId).build();
+            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
+            when(fileRepository.findByRelatedTypeAndRelatedId("equipment", equipmentId))
+                    .thenReturn(Collections.emptyList());
+
+            MultipartFile file1 = mock(MultipartFile.class);
+            when(file1.getOriginalFilename()).thenReturn("file1.jpg");
+            when(file1.getContentType()).thenReturn("image/jpeg");
+            when(file1.getSize()).thenReturn(100L);
+
+            MultipartFile file2 = mock(MultipartFile.class);
+            when(file2.getOriginalFilename()).thenReturn("file2.jpg");
+            when(file2.getContentType()).thenReturn("image/jpeg");
+            when(file2.getSize()).thenReturn(200L);
+
+            List<MultipartFile> files = List.of(file1, file2);
+            List<String> urls = List.of("http://cdn/file1.jpg", "http://cdn/file2.jpg");
+            when(fileService.saveFiles(files, "equipment")).thenReturn(urls);
+
+            // when
+            equipmentService.updateEquipmentImage(equipmentId, files);
+
+            // then
+            verify(fileRepository, never()).deleteAll(anyList());
+            verify(fileService).saveFiles(files, "equipment");
+
+            verify(fileRepository).saveAll(fileMetaListCaptor.capture());
+
+            List<FileMeta> savedFiles = fileMetaListCaptor.getValue();
+            assertThat(savedFiles).hasSize(2);
+            assertThat(savedFiles.get(0).getOriginalName()).isEqualTo("file1.jpg");
+            assertThat(savedFiles.get(0).getFilePath()).isEqualTo("http://cdn/file1.jpg");
+            assertThat(savedFiles.get(1).getOriginalName()).isEqualTo("file2.jpg");
+            assertThat(savedFiles.get(1).getFilePath()).isEqualTo("http://cdn/file2.jpg");
+        }
+
+        @Test
+        @DisplayName("성공 - 기존 이미지 삭제 후 새 이미지 업로드")
+        void updateEquipmentImage_success_existingFiles() throws Exception {
+            // given
+            Long equipmentId = 1L;
+            Equipment equipment = Equipment.builder().equipmentId(equipmentId).build();
+            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
+
+            FileMeta existingFile = mock(FileMeta.class);
+            when(fileRepository.findByRelatedTypeAndRelatedId("equipment", equipmentId))
+                    .thenReturn(List.of(existingFile));
+
+            MultipartFile newFile = mock(MultipartFile.class);
+            when(newFile.getOriginalFilename()).thenReturn("new.jpg");
+            when(newFile.getContentType()).thenReturn("image/jpeg");
+            when(newFile.getSize()).thenReturn(150L);
+
+            List<MultipartFile> files = List.of(newFile);
+            when(fileService.saveFiles(files, "equipment")).thenReturn(List.of("http://cdn/new.jpg"));
+
+            // when
+            equipmentService.updateEquipmentImage(equipmentId, files);
+
+            // then
+            verify(fileRepository).deleteAll(List.of(existingFile));
+            verify(fileService).saveFiles(files, "equipment");
+
+            verify(fileRepository).saveAll(fileMetaListCaptor.capture());
+
+            List<FileMeta> savedFiles = fileMetaListCaptor.getValue();
+            assertThat(savedFiles).hasSize(1);
+            assertThat(savedFiles.get(0).getOriginalName()).isEqualTo("new.jpg");
+            assertThat(savedFiles.get(0).getFilePath()).isEqualTo("http://cdn/new.jpg");
+        }
+
+        @Test
+        @DisplayName("예외 - 장비가 존재하지 않음")
+        void updateEquipmentImage_equipmentNotFound() {
+            // given
+            Long equipmentId = 1L;
+            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> equipmentService.updateEquipmentImage(equipmentId, List.of()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/com/equip/equiprental/equipment/service/EquipmentServiceImplTest.java
+++ b/src/test/java/com/equip/equiprental/equipment/service/EquipmentServiceImplTest.java
@@ -172,100 +172,102 @@ public class EquipmentServiceImplTest {
         }
     }
 
-//    @Nested
-//    @DisplayName("getEquipment 메서드 테스트")
-//    class getEquipment {
-//        @Test
-//        @DisplayName("성공 - 장비 조회 성공")
-//        void getEquipment_success() {
-//            // given
-//            SearchParamDto paramDto = SearchParamDto.builder()
-//                    .page(1)
-//                    .size(10)
-//                    .category("ELECTRONICS")
-//                    .build();
-//            Pageable pageable = paramDto.getPageable();
-//
-//            EquipmentDto equipment1 = EquipmentDto.builder()
-//                    .equipmentId(1L)
-//                    .category("ELECTRONICS")
-//                    .subCategory("Laptop")
-//                    .model("LG Gram")
-//                    .availableStock(5)
-//                    .totalStock(10)
-//                    .imageUrl("url1")
-//                    .build();
-//
-//            EquipmentDto equipment2 = EquipmentDto.builder()
-//                    .equipmentId(2L)
-//                    .category("ELECTRONICS")
-//                    .subCategory("Monitor")
-//                    .model("삼성 오디세이")
-//                    .availableStock(6)
-//                    .totalStock(11)
-//                    .imageUrl("url2")
-//                    .build();
-//
-//            Page<EquipmentDto> mockPage = new PageImpl<>(List.of(equipment1, equipment2), pageable, 2);
-//            when(equipmentRepository.findByFilters(paramDto, pageable)).thenReturn(mockPage);
-//
-//            // when
-//            PageResponseDto<EquipmentDto> result = equipmentService.getEquipment(paramDto);
-//
-//            // then
-//            assertThat(result).isNotNull();
-//
-//            assertThat(result.getContent()).hasSize(2);
-//            assertThat(result.getContent().get(0).getEquipmentId()).isEqualTo(1L);
-//            assertThat(result.getContent().get(0).getImageUrl()).isEqualTo("url1");
-//            assertThat(result.getContent().get(1).getEquipmentId()).isEqualTo(2L);
-//            assertThat(result.getContent().get(1).getImageUrl()).isEqualTo("url2");
-//
-//            assertThat(result.getPage()).isEqualTo(pageable.getPageNumber() + 1);
-//            assertThat(result.getSize()).isEqualTo(pageable.getPageSize());
-//            assertThat(result.getTotalElements()).isEqualTo(2);
-//            assertThat(result.getTotalPages()).isEqualTo(1);
-//            assertThat(result.getNumberOfElements()).isEqualTo(2);
-//
-//            assertThat(result.isFirst()).isTrue();
-//            assertThat(result.isLast()).isTrue();
-//            assertThat(result.isEmpty()).isFalse();
-//        }
-//
-//        @Test
-//        @DisplayName("성공 - 장비 조회 결과 없음")
-//        void getEquipment_empty() {
-//            // given
-//            SearchParamDto paramDto = SearchParamDto.builder()
-//                    .page(1)
-//                    .size(10)
-//                    .category("ELECTRONICS")
-//                    .build();
-//            Pageable pageable = paramDto.getPageable();
-//
-//            Page<EquipmentDto> emptyPage = Page.empty(pageable);
-//            when(equipmentRepository.findByFilters(paramDto, pageable)).thenReturn(emptyPage);
-//
-//            // when
-//            PageResponseDto<EquipmentDto> result = equipmentService.getEquipment(paramDto);
-//
-//            // then
-//            assertThat(result).isNotNull();
-//
-//            assertThat(result.getContent()).isEmpty();
-//            assertThat(result.isEmpty()).isTrue();
-//
-//            assertThat(result.getPage()).isEqualTo(pageable.getPageNumber() + 1);
-//            assertThat(result.getSize()).isEqualTo(pageable.getPageSize());
-//            assertThat(result.getTotalElements()).isEqualTo(0);
-//            assertThat(result.getTotalPages()).isEqualTo(0);
-//            assertThat(result.getNumberOfElements()).isEqualTo(0);
-//
-//            assertThat(result.isFirst()).isTrue();
-//            assertThat(result.isLast()).isTrue();
-//        }
-//    }
-//
+    @Nested
+    @DisplayName("getEquipment 메서드 테스트")
+    class getEquipment {
+        private SearchParamDto createEquipmentParamDto() {
+            return SearchParamDto.builder()
+                    .page(1)
+                    .size(10)
+                    .categoryId(1L)                // ELECTRONICS 카테고리 id (예시)
+                    .subCategoryId(2L)             // Laptop 서브 카테고리 id (예시)
+                    .model("LG Gram")              // 특정 모델 검색
+                    .equipmentStatus("AVAILABLE")  // 상태 필터링
+                    .build();
+        }
+
+        private EquipmentDto createEquipment(Long id, String category, String subCategory,
+                                             String model, int available, int total, String url) {
+            return EquipmentDto.builder()
+                    .equipmentId(id)
+                    .category(category)
+                    .subCategory(subCategory)
+                    .model(model)
+                    .availableStock(available)
+                    .totalStock(total)
+                    .imageUrl(url)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("성공 - 장비 조회 성공")
+        void whenEquipmentExists_thenReturnPagedResult() {
+            // given
+            SearchParamDto paramDto = createEquipmentParamDto();
+            Pageable pageable = paramDto.getPageable();
+
+            EquipmentDto equipment1 = createEquipment(1L, "ELECTRONICS", "Laptop", "LG Gram", 5, 10, "url1");
+            EquipmentDto equipment2 = createEquipment(2L, "ELECTRONICS", "Monitor", "삼성 오디세이", 6, 11, "url2");
+
+            Page<EquipmentDto> mockPage = new PageImpl<>(List.of(equipment1, equipment2), pageable, 2);
+            when(equipmentRepository.findByFilters(paramDto, pageable)).thenReturn(mockPage);
+
+            // when
+            PageResponseDto<EquipmentDto> result = equipmentService.getEquipment(paramDto);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getContent())
+                    .extracting(EquipmentDto::getEquipmentId, EquipmentDto::getImageUrl)
+                    .containsExactly(
+                            tuple(1L, "url1"),
+                            tuple(2L, "url2")
+                    );
+
+            assertThat(result.getPage()).isEqualTo(1);
+            assertThat(result.getSize()).isEqualTo(10);
+            assertThat(result.getTotalElements()).isEqualTo(2);
+            assertThat(result.getTotalPages()).isEqualTo(1);
+            assertThat(result.getNumberOfElements()).isEqualTo(2);
+
+            assertThat(result.isFirst()).isTrue();
+            assertThat(result.isLast()).isTrue();
+            assertThat(result.isEmpty()).isFalse();
+
+            verify(equipmentRepository).findByFilters(paramDto, pageable);
+        }
+
+        @Test
+        @DisplayName("성공 - 장비 조회 결과 없음")
+        void whenNoEquipmentExists_thenReturnEmptyPage() {
+            // given
+            SearchParamDto paramDto = createEquipmentParamDto();
+            Pageable pageable = paramDto.getPageable();
+
+            when(equipmentRepository.findByFilters(paramDto, pageable))
+                    .thenReturn(Page.empty(pageable));
+
+            // when
+            PageResponseDto<EquipmentDto> result = equipmentService.getEquipment(paramDto);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.isEmpty()).isTrue();
+
+            assertThat(result.getPage()).isEqualTo(1);
+            assertThat(result.getSize()).isEqualTo(10);
+            assertThat(result.getTotalElements()).isEqualTo(0);
+            assertThat(result.getTotalPages()).isEqualTo(0);
+            assertThat(result.getNumberOfElements()).isEqualTo(0);
+
+            assertThat(result.isFirst()).isTrue();
+            assertThat(result.isLast()).isTrue();
+
+            verify(equipmentRepository).findByFilters(paramDto, pageable);
+        }
+    }
+
 //    @Nested
 //    @DisplayName("getEquipmentItem 메서드 테스트")
 //    class getEquipmentItem {
@@ -284,7 +286,7 @@ public class EquipmentServiceImplTest {
 //
 //            Equipment equipment = Equipment.builder()
 //                    .equipmentId(equipmentId)
-//                    .category(EquipmentCategory.ELECTRONICS)
+//                    .category(Category.ELECTRONICS)
 //                    .subCategory("Laptop")
 //                    .model("LG Gram")
 //                    .build();

--- a/src/test/java/com/equip/equiprental/equipment/service/EquipmentServiceImplTest.java
+++ b/src/test/java/com/equip/equiprental/equipment/service/EquipmentServiceImplTest.java
@@ -268,144 +268,138 @@ public class EquipmentServiceImplTest {
         }
     }
 
-//    @Nested
-//    @DisplayName("getEquipmentItem 메서드 테스트")
-//    class getEquipmentItem {
-//        @Test
-//        @DisplayName("성공 - 장비와 아이템 조회 성공")
-//        void getEquipmentItem_success() {
-//            // given
-//            Long equipmentId = 1L;
-//            SearchParamDto paramDto = SearchParamDto.builder()
-//                    .page(1)
-//                    .size(10)
-//                    .equipmentStatus("AVAILABLE")
-//                    .build();
-//
-//            Pageable pageable = paramDto.getPageable();
-//
-//            Equipment equipment = Equipment.builder()
-//                    .equipmentId(equipmentId)
-//                    .category(Category.ELECTRONICS)
-//                    .subCategory("Laptop")
-//                    .model("LG Gram")
-//                    .build();
-//
-//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
-//            when(equipmentItemRepository.countByEquipment_EquipmentIdAndStatus(equipmentId, EquipmentStatus.AVAILABLE))
-//                    .thenReturn(5);
-//            when(equipmentItemRepository.countByEquipment_EquipmentId(equipmentId))
-//                    .thenReturn(10);
-//            when(fileRepository.findUrlsByEquipmentId(equipmentId))
-//                    .thenReturn(List.of("url1"));
-//
-//            EquipmentItemDto item1 = EquipmentItemDto.builder().equipmentItemId(1L).status(EquipmentStatus.AVAILABLE).build();
-//            EquipmentItemDto item2 = EquipmentItemDto.builder().equipmentItemId(2L).status(EquipmentStatus.AVAILABLE).build();
-//            Page<EquipmentItemDto> itemsPage = new PageImpl<>(List.of(item1, item2), pageable, 2);
-//
-//            when(equipmentItemRepository.findByStatus(equipmentId, EquipmentStatus.AVAILABLE, pageable))
-//                    .thenReturn(itemsPage);
-//
-//            // when
-//            EquipmentItemListDto result = equipmentService.getEquipmentItem(equipmentId, paramDto);
-//
-//            // then
-//            // 장비 요약 검증
-//            assertThat(result.getEquipmentSummary().getEquipmentId()).isEqualTo(equipmentId);
-//            assertThat(result.getEquipmentSummary().getAvailableStock()).isEqualTo(5);
-//            assertThat(result.getEquipmentSummary().getTotalStock()).isEqualTo(10);
-//            assertThat(result.getEquipmentSummary().getImageUrl()).isEqualTo("url1");
-//
-//            // 장비 아이템 페이지 검증
-//            assertThat(result.getEquipmentItems().getContent()).hasSize(2)
-//                    .extracting(EquipmentItemDto::getEquipmentItemId)
-//                    .containsExactly(1L, 2L);
-//
-//            assertThat(result.getEquipmentItems()).extracting(
-//                    PageResponseDto::getPage,
-//                    PageResponseDto::getSize,
-//                    PageResponseDto::getTotalElements,
-//                    PageResponseDto::getTotalPages,
-//                    PageResponseDto::getNumberOfElements,
-//                    PageResponseDto::isFirst,
-//                    PageResponseDto::isLast,
-//                    PageResponseDto::isEmpty
-//            ).containsExactly(1, 10, 2L, 1, 2, true, true, false);
-//        }
-//
-//        @Test
-//        @DisplayName("성공 - 장비는 존재하지만 아이템 없음 (빈 페이지)")
-//        void getEquipmentItem_emptyItems() {
-//            // given
-//            Long equipmentId = 1L;
-//            SearchParamDto paramDto = SearchParamDto.builder()
-//                    .page(1)
-//                    .size(10)
-//                    .equipmentStatus("AVAILABLE")
-//                    .build();
-//
-//            Pageable pageable = paramDto.getPageable();
-//
-//            Equipment equipment = Equipment.builder()
-//                    .equipmentId(equipmentId)
-//                    .category(EquipmentCategory.ELECTRONICS)
-//                    .subCategory("Laptop")
-//                    .model("LG Gram")
-//                    .build();
-//
-//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
-//            when(equipmentItemRepository.countByEquipment_EquipmentIdAndStatus(equipmentId, EquipmentStatus.AVAILABLE))
-//                    .thenReturn(0); // 아이템 없음
-//            when(equipmentItemRepository.countByEquipment_EquipmentId(equipmentId))
-//                    .thenReturn(0); // 전체 재고도 0
-//            when(fileRepository.findUrlsByEquipmentId(equipmentId))
-//                    .thenReturn(List.of("url1"));
-//
-//            Page<EquipmentItemDto> emptyPage = Page.empty(pageable);
-//            when(equipmentItemRepository.findByStatus(equipmentId, EquipmentStatus.AVAILABLE, pageable))
-//                    .thenReturn(emptyPage);
-//
-//            // when
-//            EquipmentItemListDto result = equipmentService.getEquipmentItem(equipmentId, paramDto);
-//
-//            // then
-//            // 장비 요약 검증
-//            assertThat(result.getEquipmentSummary().getEquipmentId()).isEqualTo(equipmentId);
-//            assertThat(result.getEquipmentSummary().getAvailableStock()).isEqualTo(0);
-//            assertThat(result.getEquipmentSummary().getTotalStock()).isEqualTo(0);
-//            assertThat(result.getEquipmentSummary().getImageUrl()).isEqualTo("url1");
-//
-//            // 장비 아이템 페이지 검증 (빈 페이지)
-//            assertThat(result.getEquipmentItems().getContent()).isEmpty();
-//            assertThat(result.getEquipmentItems().isEmpty()).isTrue();
-//
-//            assertThat(result.getEquipmentItems()).extracting(
-//                    PageResponseDto::getPage,
-//                    PageResponseDto::getSize,
-//                    PageResponseDto::getTotalElements,
-//                    PageResponseDto::getTotalPages,
-//                    PageResponseDto::getNumberOfElements,
-//                    PageResponseDto::isFirst,
-//                    PageResponseDto::isLast
-//            ).containsExactly(1, 10, 0L, 0, 0, true, true);
-//        }
-//
-//        @Test
-//        @DisplayName("예외 - 장비가 존재하지 않음")
-//        void getEquipmentItem_notFound() {
-//            Long equipmentId = 1L;
-//            SearchParamDto paramDto = SearchParamDto.builder().build();
-//
-//            // Mock: 장비가 존재하지 않음
-//            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.empty());
-//
-//            // 검증: CustomException 발생
-//            assertThatThrownBy(() -> equipmentService.getEquipmentItem(equipmentId, paramDto))
-//                    .isInstanceOf(CustomException.class)
-//                    .extracting("errorType")
-//                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
-//        }
-//    }
+    @Nested
+    @DisplayName("getEquipmentItem 메서드 테스트")
+    class getEquipmentItem {
+        private SearchParamDto createParamDto(String status) {
+            return SearchParamDto.builder()
+                    .page(1)
+                    .size(10)
+                    .equipmentStatus(status)
+                    .build();
+        }
+
+        private Equipment createEquipment(Long equipmentId, String categoryLabel, String subCategoryLabel, String model) {
+            Category category = Category.builder()
+                    .categoryId(1L)
+                    .label(categoryLabel)
+                    .build();
+
+            SubCategory subCategory = SubCategory.builder()
+                    .subCategoryId(1L)
+                    .label(subCategoryLabel)
+                    .category(category)
+                    .build();
+
+            return Equipment.builder()
+                    .equipmentId(equipmentId)
+                    .subCategory(subCategory)
+                    .model(model)
+                    .build();
+        }
+
+        private EquipmentItemDto createItem(Long id, EquipmentStatus status) {
+            return EquipmentItemDto.builder()
+                    .equipmentItemId(id)
+                    .status(status)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("성공 - 장비와 아이템 조회 성공")
+        void getEquipmentItem_success() {
+            // given
+            Long equipmentId = 1L;
+            SearchParamDto paramDto = createParamDto("AVAILABLE");
+            Pageable pageable = paramDto.getPageable();
+
+            Equipment equipment = createEquipment(equipmentId, "ELECTRONICS", "Laptop", "LG Gram");
+
+            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
+            when(equipmentItemRepository.countByEquipment_EquipmentIdAndStatus(equipmentId, EquipmentStatus.AVAILABLE))
+                    .thenReturn(5);
+            when(equipmentItemRepository.countByEquipment_EquipmentId(equipmentId))
+                    .thenReturn(10);
+            when(fileRepository.findUrlsByEquipmentId(equipmentId))
+                    .thenReturn(List.of("url1"));
+
+            EquipmentItemDto item1 = createItem(1L, EquipmentStatus.AVAILABLE);
+            EquipmentItemDto item2 = createItem(2L, EquipmentStatus.AVAILABLE);
+            Page<EquipmentItemDto> itemsPage = new PageImpl<>(List.of(item1, item2), pageable, 2);
+
+            when(equipmentItemRepository.findByStatus(equipmentId, EquipmentStatus.AVAILABLE, pageable))
+                    .thenReturn(itemsPage);
+
+            // when
+            EquipmentItemListDto result = equipmentService.getEquipmentItem(equipmentId, paramDto);
+
+            // then
+            assertThat(result.getEquipmentSummary().getEquipmentId()).isEqualTo(equipmentId);
+            assertThat(result.getEquipmentSummary().getAvailableStock()).isEqualTo(5);
+            assertThat(result.getEquipmentSummary().getTotalStock()).isEqualTo(10);
+            assertThat(result.getEquipmentSummary().getImageUrl()).isEqualTo("url1");
+
+            assertThat(result.getEquipmentItems().getContent())
+                    .extracting(EquipmentItemDto::getEquipmentItemId)
+                    .containsExactly(1L, 2L);
+
+            assertThat(result.getEquipmentItems().getPage()).isEqualTo(1);
+            assertThat(result.getEquipmentItems().getSize()).isEqualTo(10);
+            assertThat(result.getEquipmentItems().getTotalElements()).isEqualTo(2);
+            assertThat(result.getEquipmentItems().getTotalPages()).isEqualTo(1);
+            assertThat(result.getEquipmentItems().getNumberOfElements()).isEqualTo(2);
+            assertThat(result.getEquipmentItems().isFirst()).isTrue();
+            assertThat(result.getEquipmentItems().isLast()).isTrue();
+
+            verify(equipmentRepository).findById(equipmentId);
+            verify(equipmentItemRepository).findByStatus(equipmentId, EquipmentStatus.AVAILABLE, pageable);
+        }
+
+        @Test
+        @DisplayName("성공 - 장비는 존재하지만 아이템 없음 (빈 페이지)")
+        void getEquipmentItem_emptyItems() {
+            Long equipmentId = 1L;
+            SearchParamDto paramDto = createParamDto("AVAILABLE");
+            Pageable pageable = paramDto.getPageable();
+
+            Equipment equipment = createEquipment(equipmentId, "ELECTRONICS", "Laptop", "LG Gram");
+
+            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
+            when(equipmentItemRepository.countByEquipment_EquipmentIdAndStatus(equipmentId, EquipmentStatus.AVAILABLE))
+                    .thenReturn(0);
+            when(equipmentItemRepository.countByEquipment_EquipmentId(equipmentId))
+                    .thenReturn(0);
+            when(fileRepository.findUrlsByEquipmentId(equipmentId))
+                    .thenReturn(List.of("url1"));
+
+            when(equipmentItemRepository.findByStatus(equipmentId, EquipmentStatus.AVAILABLE, pageable))
+                    .thenReturn(Page.empty(pageable));
+
+            // when
+            EquipmentItemListDto result = equipmentService.getEquipmentItem(equipmentId, paramDto);
+
+            // then
+            assertThat(result.getEquipmentSummary().getAvailableStock()).isEqualTo(0);
+            assertThat(result.getEquipmentSummary().getTotalStock()).isEqualTo(0);
+            assertThat(result.getEquipmentSummary().getImageUrl()).isEqualTo("url1");
+            assertThat(result.getEquipmentItems().getContent()).isEmpty();
+            assertThat(result.getEquipmentItems().isEmpty()).isTrue();
+        }
+
+        @Test
+        @DisplayName("예외 - 장비가 존재하지 않음")
+        void getEquipmentItem_notFound() {
+            Long equipmentId = 1L;
+            SearchParamDto paramDto = SearchParamDto.builder().build();
+
+            when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> equipmentService.getEquipmentItem(equipmentId, paramDto))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.EQUIPMENT_NOT_FOUND);
+        }
+    }
 
     @Nested
     @DisplayName("increaseStock 메서드 테스트")


### PR DESCRIPTION
## 개요
- #18 

## 타입
- **feat:** 새로운 기능 추가

## 작업 사항
- 건의/문의 게시판 도메인 엔티티, 레포지토리, 서비스, 컨트롤러 구현
- 게시글 작성/조회/수정/삭제(CRUD) API 추가
- 게시판 목록 페이징 및 검색 구현
- 게시글 타입별 파일 저장 경로 분류
- 댓글 등록/조회/삭제 및 페이징 구현
- 댓글에 관리자의 공식 답변 기재 시 게시글 수정 불가