### PR TITLE
fix: 장비 파일 저장 경로 다단계 라벨 기반 구조 개선

### DIFF
--- a/src/main/java/com/equip/equiprental/common/config/FileProperties.java
+++ b/src/main/java/com/equip/equiprental/common/config/FileProperties.java
@@ -19,8 +19,19 @@ public class FileProperties {
 
     public String getFullPath(String typeKey) {
         String[] parts = typeKey.split("_");
+        if (parts.length == 0) return storagePath;
+
+        // 첫 번째 부분은 directories 매핑 사용
         String dir1 = directories.getOrDefault(parts[0], parts[0]);
-        String dir2 = (parts.length > 1) ? parts[1] : ""; // 안전하게 처리
-        return Paths.get(storagePath, dir1, dir2).toString();
+
+        // 나머지 부분을 하위 디렉토리로 사용
+        String[] subDirs = (parts.length > 1) ? java.util.Arrays.copyOfRange(parts, 1, parts.length) : new String[0];
+
+        // dir1 + subDirs를 합쳐서 가변인자로 전달
+        String[] fullDirs = new String[subDirs.length + 1];
+        fullDirs[0] = dir1;
+        System.arraycopy(subDirs, 0, fullDirs, 1, subDirs.length);
+
+        return Paths.get(storagePath, fullDirs).toString();
     }
 }

--- a/src/main/java/com/equip/equiprental/equipment/service/EquipmentServiceImpl.java
+++ b/src/main/java/com/equip/equiprental/equipment/service/EquipmentServiceImpl.java
@@ -66,7 +66,12 @@ public class EquipmentServiceImpl implements EquipmentService {
 
         if(files != null && !files.isEmpty()) {
             int fileOrder = 0;
-            List<String> fileUrls = fileService.saveFiles(files, "equipment");
+
+            String categoryLabel = equipment.getSubCategory().getCategory().getLabel();
+            String subCategoryLabel = equipment.getSubCategory().getLabel();
+            String typeKey = String.format("equipment_%s_%s", categoryLabel, subCategoryLabel);
+
+            List<String> fileUrls = fileService.saveFiles(files, typeKey);
 
             for (int i = 0; i < files.size(); i++) {
                 MultipartFile file = files.get(i);


### PR DESCRIPTION
## 개요
- #22 

## 개선 사항
- `register()`에서 typeKey를 **라벨 기반으로 세분화**
```java
String categoryLabel = equipment.getSubCategory().getCategory().getLabel();
String subCategoryLabel = equipment.getSubCategory().getLabel();
String typeKey = String.format("equipment_%s_%s", categoryLabel, subCategoryLabel);
```
- FileProperties.getFullPath() 수정
  - _로 나눈 모든 하위 디렉토리를 반영
  - 예: "equipment_전자기기_노트북" → storagePath/equipment/전자기기/노트북
- FileMeta 저장 시 relatedType과 filePath 정상 반영